### PR TITLE
Modified saveToDirectory() in UpdateSummariesParallel to add continued directory numbering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,2 @@
-*~
-*.bak
-build_dir*
-bin/
-bin_test/
-thirdparty/
+bin
+build_dir

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.gitignore
 bin
 build_dir

--- a/.gitignore~
+++ b/.gitignore~
@@ -1,0 +1,2 @@
+bin
+build_dir

--- a/CMakeLists.txt~
+++ b/CMakeLists.txt~
@@ -1,0 +1,74 @@
+###############################################################################
+# General settings
+
+# Some settings related to building/installing libraries and header files
+# Set this to STATIC if you want to build static libraries instead.
+set(SHARED_OR_STATIC "SHARED")
+set(LIB_INSTALL_DIR /usr/local/lib)
+set(INCLUDE_INSTALL_DIR /usr/local/include)
+
+
+# Never build inside the source tree
+set(CMAKE_DISABLE_SOURCE_CHANGES ON)
+set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
+
+# Project name is not mandatory, but you should use it
+project(OO_DMP_BBO)
+
+# States that CMake required version must be greater than 2.6
+cmake_minimum_required(VERSION 2.6)
+
+# Some flags for CXX
+set(CMAKE_CXX_FLAGS "-Wall -std=c++0x")
+set(CMAKE_CXX_FLAGS_DEBUG "-O0 -ggdb")
+set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG")
+
+# Appends the cmake/modules path inside the MAKE_MODULE_PATH variable which stores the
+# directories of additional CMake modules (ie. MacroOutOfSourceBuild.cmake):
+set(CMAKE_MODULE_PATH ${oo_dmp_bbo_SOURCE_DIR}/cmake/modules "${CMAKE_SOURCE_DIR}/src/functionapproximators/" ${CMAKE_MODULE_PATH})
+
+include_directories(${CMAKE_SOURCE_DIR}/src)
+link_directories(${CMAKE_SOURCE_DIR}/lib)
+
+IF(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+  SET(CMAKE_INSTALL_PREFIX ${CMAKE_SOURCE_DIR} CACHE PATH "Comment" FORCE)
+ENDIF(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+
+###############################################################################
+# See if LWPR is installed. 
+find_package(LWPR)
+if(LWPR_FOUND)
+  SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DUSE_LWPR")
+endif()
+
+###############################################################################
+# Find boost packages
+find_package( Boost 1.34 COMPONENTS filesystem system serialization REQUIRED)
+link_directories ( ${Boost_LIBRARY_DIRS} )
+include_directories ( ${Boost_INCLUDE_DIRS} )
+
+###############################################################################
+# Things to compile are in the src/ directory
+add_subdirectory(src)
+
+###############################################################################
+# Generate doxygen documentation from CMake
+# http://www.bluequartz.net/projects/EIM_Segmentation/SoftwareDocumentation/html/usewithcmakeproject.html
+option(BUILD_DOCUMENTATION "Use Doxygen to create the HTML based API documentation" ON)
+if(BUILD_DOCUMENTATION)
+  FIND_PACKAGE(Doxygen)
+  if (NOT DOXYGEN_FOUND)
+    message(FATAL_ERROR 
+      "Doxygen is needed to build the documentation. Please install it correctly")
+  endif()
+  #-- Configure the Template Doxyfile for our specific project
+  configure_file(${CMAKE_SOURCE_DIR}/docs/Doxyfile.in 
+                 ${PROJECT_BINARY_DIR}/Doxyfile  @ONLY IMMEDIATE)
+  #-- Add a custom target to run Doxygen when ever the project is built
+  add_custom_target (Docs  
+  	COMMAND ${DOXYGEN_EXECUTABLE} ${PROJECT_BINARY_DIR}/Doxyfile
+  	SOURCES ${PROJECT_BINARY_DIR}/Doxyfile)
+  # IF you do NOT want the documentation to be generated EVERY time you build the project
+  # then leave out the 'ALL' keyword from the above command.
+endif()
+

--- a/src/bbo/CostFunction.hpp
+++ b/src/bbo/CostFunction.hpp
@@ -20,7 +20,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
  */
-
+#define EIGEN2_SUPPORT
 #ifndef COSTFUNCTION_H
 #define COSTFUNCTION_H
 

--- a/src/bbo/CostFunction.hpp~
+++ b/src/bbo/CostFunction.hpp~
@@ -1,0 +1,67 @@
+/**
+ * @file   CostFunction.hpp
+ * @brief  CostFunction class header file.
+ * @author Freek Stulp
+ *
+ * This file is part of DmpBbo, a set of libraries and programs for the 
+ * black-box optimization of dynamical movement primitives.
+ * Copyright (C) 2014 Freek Stulp, ENSTA-ParisTech
+ * 
+ * DmpBbo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ * 
+ * DmpBbo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef COSTFUNCTION_H
+#define COSTFUNCTION_H
+
+#include <vector>
+#include <eigen3/Eigen/Core>
+
+namespace DmpBbo {
+
+/** Interface for cost functions, which define a cost_function.
+ * For further information see the section on \ref sec_bbo_task_and_task_solver
+ */
+class CostFunction
+{
+public:
+  /** The cost function which defines the cost_function.
+   *
+   * \param[in] samples The samples 
+   * \param[out] costs The scalar cost for each sample.
+   */
+  virtual void evaluate(const Eigen::MatrixXd& samples, Eigen::VectorXd& costs) const = 0;
+  
+  /** Returns a string representation of the object.
+   * \return A string representation of the object.
+   */
+  virtual std::string toString(void) const = 0;
+
+  /** Write to output stream. 
+   *  \param[in] output Output stream to which to write to 
+   *  \param[in] cost_function CostFunction object to write
+   *  \return Output to which the object was written 
+   *
+   *  \remark Calls virtual function CostFunction::toString, which must be implemented by
+   * subclasses: http://stackoverflow.com/questions/4571611/virtual-operator
+   */ 
+  friend std::ostream& operator<<(std::ostream& output, const CostFunction& cost_function) {
+    output << cost_function.toString();
+    return output;
+  }
+};
+
+}
+
+#endif
+

--- a/src/bbo/DistributionGaussian.cpp
+++ b/src/bbo/DistributionGaussian.cpp
@@ -20,7 +20,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
  */
-
+#define EIGEN2_SUPPORT
 #include "bbo/DistributionGaussian.hpp"
 
 #include <iomanip>

--- a/src/bbo/DistributionGaussian.cpp~
+++ b/src/bbo/DistributionGaussian.cpp~
@@ -1,0 +1,114 @@
+/**
+ * @file   DistributionGaussian.cpp
+ * @brief  DistributionGaussian class source file.
+ * @author Freek Stulp
+ *
+ * This file is part of DmpBbo, a set of libraries and programs for the 
+ * black-box optimization of dynamical movement primitives.
+ * Copyright (C) 2014 Freek Stulp, ENSTA-ParisTech
+ * 
+ * DmpBbo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ * 
+ * DmpBbo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "bbo/DistributionGaussian.hpp"
+
+#include <iomanip>
+
+#include <boost/random.hpp>
+#include <boost/random/variate_generator.hpp>
+#include <boost/random/normal_distribution.hpp>
+
+#include <eigen3/Eigen/Core>
+
+#include "dmpbbo_io/EigenBoostSerialization.hpp"
+
+
+using namespace std;
+using namespace Eigen;
+
+namespace DmpBbo {
+
+// Initialize random number generator
+boost::mt19937 DistributionGaussian::rng = boost::mt19937(getpid() + time(0));
+
+// Initialize uni-variate unit normal distribution
+boost::variate_generator<boost::mt19937&, boost::normal_distribution<> >
+*DistributionGaussian::normal_distribution_unit
+   = new boost::variate_generator<boost::mt19937&, boost::normal_distribution<> >(
+        rng, 
+        boost::normal_distribution<>(0, 1)
+     );
+
+
+DistributionGaussian::DistributionGaussian(const VectorXd& mean, const MatrixXd& covar) 
+{
+  mean_ = mean;
+  set_covar(covar);
+}
+
+DistributionGaussian* DistributionGaussian::clone(void) const
+{
+  return new DistributionGaussian(mean(),covar()); 
+}
+
+void DistributionGaussian::set_mean(const VectorXd& mean) { 
+  assert(mean.size()==mean_.size());  
+  mean_ = mean;
+}
+
+
+void DistributionGaussian::set_covar(const MatrixXd& covar) { 
+  assert(covar.cols()==covar.rows());
+  assert(covar.rows()==mean_.size());
+  covar_ = covar;
+  covar_decomposed_ = MatrixXd::Zero(0,0);
+}
+
+void DistributionGaussian::generateSamples(int n_samples, MatrixXd& samples) const
+{
+  if (covar_decomposed_.size()==0)
+  {
+    // Now perform the Cholesky decomposition, which makes it easier to generate samples. 
+    MatrixXd A(covar_.llt().matrixL());
+    covar_decomposed_ = A;
+    // Remark: it would have been better to do this in the constructor and set_covar, 
+    // but I couldn't get it to work with boost::serialization (I tried hard)
+  }
+  
+  
+  int n_dims = mean_.size();
+  samples.resize(n_samples,n_dims);
+  
+  // http://en.wikipedia.org/wiki/Multivariate_normal_distribution#Drawing_values_from_the_distribution
+  VectorXd z(n_dims);
+  for (int i_sample=0; i_sample<n_samples; i_sample++)
+  {
+    // Generate vector with samples from standard normal distribution N(0,1) 
+    for (int i_dim=0; i_dim<n_dims; i_dim++)
+      z(i_dim) = (*normal_distribution_unit)();
+
+    // Compute x = mu + Az
+    samples.row(i_sample) = mean_ + covar_decomposed_*z;
+  }  
+}
+
+
+std::ostream& operator<<(std::ostream& output, const DistributionGaussian& distribution)
+{
+  output << "N([" << toString(distribution.mean_) << "], ["<< toString(distribution.covar_) << "])";
+  return output;
+}
+
+
+}

--- a/src/bbo/DistributionGaussian.hpp
+++ b/src/bbo/DistributionGaussian.hpp
@@ -20,7 +20,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
  */
-
+#define EIGEN2_SUPPORT
 #ifndef DISTRIBUTIONGAUSSIAN_H
 #define DISTRIBUTIONGAUSSIAN_H   
 

--- a/src/bbo/DistributionGaussian.hpp
+++ b/src/bbo/DistributionGaussian.hpp
@@ -96,6 +96,10 @@ public:
 private:
   /** Boost's random number generator. Shared by all object instances. */
   static boost::mt19937 rng;
+  
+  /** Generator for samples from a univariate unit normal distribution. Shared by all object instances. */
+  static boost::variate_generator<boost::mt19937&, boost::normal_distribution<> > *normal_distribution_unit;
+
   /** Mean of the distribution */
   Eigen::VectorXd mean_;
   /** Covariance matrix of the distribution */

--- a/src/bbo/DistributionGaussian.hpp~
+++ b/src/bbo/DistributionGaussian.hpp~
@@ -1,0 +1,134 @@
+/**
+ * @file   DistributionGaussian.hpp
+ * @brief  DistributionGaussian class header file.
+ * @author Freek Stulp
+ *
+ * This file is part of DmpBbo, a set of libraries and programs for the 
+ * black-box optimization of dynamical movement primitives.
+ * Copyright (C) 2014 Freek Stulp, ENSTA-ParisTech
+ * 
+ * DmpBbo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ * 
+ * DmpBbo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef DISTRIBUTIONGAUSSIAN_H
+#define DISTRIBUTIONGAUSSIAN_H   
+
+#include "dmpbbo_io/EigenBoostSerialization.hpp"
+
+#include <vector>
+#include <sstream>
+#include <algorithm>
+#include <eigen3/Eigen/Core>
+#include <eigen3/Eigen/Cholesky>
+
+#include <boost/random.hpp>
+
+namespace DmpBbo {
+
+/** \brief A class for representing a Gaussian distribution.
+ *
+ * This is mainly a wrapper around boost functionality
+ * The reason to make the wrapper is to provide functionality for serialization/deserialization.
+ */
+class DistributionGaussian
+{
+public:
+  /** Construct the Gaussian distribution with a mean and covariance matrix.
+   *  \param[in] mean Mean of the distribution
+   *  \param[in] covar Covariance matrix of the distribution
+   */
+  DistributionGaussian(const Eigen::VectorXd& mean, const Eigen::MatrixXd& covar);
+  
+  /** Generate samples from the distribution.
+   *  \param[in] n_samples Number of samples to sample
+   *  \param[in] samples the samples themselves (size n_samples X dim(mean)
+   */
+  void generateSamples(int n_samples, Eigen::MatrixXd& samples) const;
+  
+  /** Make a deep copy of the object.
+   * \return A deep copy of the object.
+   */
+  DistributionGaussian* clone(void) const;
+  
+  /**
+   * Accessor get function for the mean.
+   * \return The mean of the distribution
+   */
+  const Eigen::VectorXd& mean(void) const   { return mean_;   }
+  
+  /**
+   * Accessor get function for the covariance matrix.
+   * \return The covariance matrix of the distribution
+   */
+  const Eigen::MatrixXd& covar(void) const { return covar_; }
+  
+  /**
+   * Accessor set function for the mean.
+   * \param[in] mean The new mean of the distribution
+   */
+  void set_mean(const Eigen::VectorXd& mean);
+  
+  /**
+   * Accessor set function for the covar.
+   * \param[in] covar The new covariance matrix of the distribution
+   */
+  void set_covar(const Eigen::MatrixXd& covar);
+
+  /** Print to output stream. 
+   *
+   *  \param[in] output  Output stream to which to write to
+   *  \param[in] distribution Distribution to write
+   *  \return    Output stream
+   */ 
+  friend std::ostream& operator<<(std::ostream& output, const DistributionGaussian& distribution);
+  
+private:
+  /** Boost's random number generator. Shared by all object instances. */
+  static boost::mt19937 rng;
+  
+  /** Generator for samples from a univariate unit normal distribution. Shared by all object instances. */
+  static boost::variate_generator<boost::mt19937&, boost::normal_distribution<> > *normal_distribution_unit;
+
+  /** Mean of the distribution */
+  Eigen::VectorXd mean_;
+  /** Covariance matrix of the distribution */
+  Eigen::MatrixXd covar_;  
+  /** Cholesky decomposition of the covariance matrix of the distribution. This cached variable makes it easier to generate samples. */
+  mutable Eigen::MatrixXd covar_decomposed_; 
+  
+  /** Give boost serialization access to private members. */  
+  friend class boost::serialization::access;
+  
+  /** Serialize class data members to boost archive. 
+   * \param[in] ar Boost archive
+   * \param[in] version Version of the class
+   * See http://www.boost.org/doc/libs/1_55_0/libs/serialization/doc/tutorial.html#simplecase
+   */
+  template<class Archive>
+  void serialize(Archive & ar, const unsigned int version)
+  {
+    ar & BOOST_SERIALIZATION_NVP(mean_);
+    ar & BOOST_SERIALIZATION_NVP(covar_);
+  }
+
+};
+
+}
+
+/** Don't add version information to archives. */
+BOOST_CLASS_IMPLEMENTATION(DmpBbo::DistributionGaussian,boost::serialization::object_serializable);
+
+
+
+#endif

--- a/src/bbo/ExperimentBBO.hpp
+++ b/src/bbo/ExperimentBBO.hpp
@@ -20,7 +20,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
  */
-
+#define EIGEN2_SUPPORT
 #ifndef EXPERIMENTBBO_H
 #define EXPERIMENTBBO_H
 

--- a/src/bbo/ExperimentBBO.hpp~
+++ b/src/bbo/ExperimentBBO.hpp~
@@ -1,0 +1,158 @@
+/**
+ * @file   ExperimentBBO.hpp
+ * @brief  ExperimentBBO class header file.
+ * @author Freek Stulp
+ *
+ * This file is part of DmpBbo, a set of libraries and programs for the 
+ * black-box optimization of dynamical movement primitives.
+ * Copyright (C) 2014 Freek Stulp, ENSTA-ParisTech
+ * 
+ * DmpBbo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ * 
+ * DmpBbo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef EXPERIMENTBBO_H
+#define EXPERIMENTBBO_H
+
+#include <vector>
+#include <eigen3/Eigen/Core>
+
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/nvp.hpp>
+
+namespace DmpBbo {
+
+class CostFunction;
+class Task;
+class TaskSolver;
+class DistributionGaussian;
+class Updater;
+  
+/** POD class to store all objects relevant to running and evolutionary optimization. */
+class ExperimentBBO
+{
+
+public:
+  /** Constructor.
+   * \param[in] cost_function_arg The cost function to optimize
+   * \param[in] initial_distribution_arg The initial parameter distribution
+   * \param[in] updater_arg The Updater used to update the parameters
+   * \param[in] n_updates_arg The number of updates to perform
+   * \param[in] n_samples_per_update_arg The number of samples per update
+   */
+  ExperimentBBO(
+    CostFunction* cost_function_arg,
+    DistributionGaussian* initial_distribution_arg,
+    Updater* updater_arg,
+    int n_updates_arg,
+    int n_samples_per_update_arg
+  )
+  :
+    cost_function(cost_function_arg),
+    task(NULL),
+    task_solver(NULL),
+    initial_distribution(initial_distribution_arg),
+    updater(updater_arg),
+    n_updates(n_updates_arg),
+    n_samples_per_update(n_samples_per_update_arg)
+  {}
+  
+  /** Constructor.
+   * \param[in] task_arg The Task to optimize
+   * \param[in] task_solver_arg The TaskSolver that will solve the task
+   * \param[in] initial_distribution_arg The initial parameter distribution
+   * \param[in] updater_arg The Updater used to update the parameters
+   * \param[in] n_updates_arg The number of updates to perform
+   * \param[in] n_samples_per_update_arg The number of samples per update
+   */
+  ExperimentBBO(
+    Task* task_arg,
+    TaskSolver* task_solver_arg,
+    DistributionGaussian* initial_distribution_arg,
+    Updater* updater_arg,
+    int n_updates_arg,
+    int n_samples_per_update_arg
+  )
+  :
+    cost_function(NULL),
+    task(task_arg),
+    task_solver(task_solver_arg),
+    initial_distribution(initial_distribution_arg),
+    updater(updater_arg),
+    n_updates(n_updates_arg),
+    n_samples_per_update(n_samples_per_update_arg)
+  {}
+
+  /** Cost function to be used during evaluation.
+   * If it is NULL, ExperimentBBO::task and ExperimentBBO::task_solver must be set.
+   */
+  const CostFunction* cost_function;
+  
+  /** Task to be used during evaluation.
+   * If it is NULL, ExperimentBBO::cost_function must be set.
+   */
+  const Task* task;
+
+  /** Task solver to be used for a rollout.
+   * If it is NULL, ExperimentBBO::cost_function must be set.
+   */
+  const TaskSolver* task_solver;
+  
+  /** The initial parameter distribution for the search. */
+  const DistributionGaussian* const initial_distribution; 
+
+  /** The updater used to update the parameters of the distribution. */
+  const Updater* updater;
+
+  /** The number of updates to perform. */
+  int n_updates;
+  
+  /** The number of samples per update. */
+  int n_samples_per_update;
+
+  /** Serialize class data members to boost archive. 
+   * \param[in] ar Boost archive
+   * \param[in] version Version of the class
+   * See http://www.boost.org/doc/libs/1_55_0/libs/serialization/doc/tutorial.html#simplecase
+   */
+  template<class Archive>
+  void serialize(Archive & ar, const unsigned int version)
+  {
+    ar & BOOST_SERIALIZATION_NVP(cost_function);
+    ar & BOOST_SERIALIZATION_NVP(task);
+    ar & BOOST_SERIALIZATION_NVP(task_solver);
+    ar & BOOST_SERIALIZATION_NVP(initial_distribution);
+    ar & BOOST_SERIALIZATION_NVP(updater);
+    ar & BOOST_SERIALIZATION_NVP(n_updates);
+    ar & BOOST_SERIALIZATION_NVP(n_samples_per_update);
+  }
+
+};
+
+}
+
+#include <boost/serialization/level.hpp>
+/** Don't add version information to archives. */
+BOOST_CLASS_IMPLEMENTATION(DmpBbo::ExperimentBBO,boost::serialization::object_serializable);
+
+/*
+class ExperimentBBOResults
+{
+  ExperimentBBO experiment;
+  vector<UpdateSummary> update_summaries;
+  vector<vector<MatrixXd>> cost_vars;
+}
+*/
+
+
+#endif 

--- a/src/bbo/Task.hpp
+++ b/src/bbo/Task.hpp
@@ -20,7 +20,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
  */
- 
+#define EIGEN2_SUPPORT 
 #ifndef TASK_H
 #define TASK_H
 

--- a/src/bbo/Task.hpp~
+++ b/src/bbo/Task.hpp~
@@ -1,0 +1,116 @@
+/**
+ * @file   Task.hpp
+ * @brief  Task class header file.
+ * @author Freek Stulp
+ *
+ * This file is part of DmpBbo, a set of libraries and programs for the 
+ * black-box optimization of dynamical movement primitives.
+ * Copyright (C) 2014 Freek Stulp, ENSTA-ParisTech
+ * 
+ * DmpBbo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ * 
+ * DmpBbo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
+#ifndef TASK_H
+#define TASK_H
+
+#include <vector>
+#include <eigen3/Eigen/Core>
+
+#include <boost/serialization/access.hpp>
+
+namespace DmpBbo {
+
+/** Interface for cost functions, which define a task.
+ * For further information see the section on \ref sec_bbo_task_and_task_solver
+ */
+class Task
+{
+public:
+  /** The cost function which defines the task.
+   *
+   * \param[in] cost_vars All the variables relevant to computing the cost. These are determined by TaskSolver::performRollouts(). For further information see the section on \ref sec_bbo_task_and_task_solver
+   * \param[out] costs The scalar cost for each sample.
+   */
+  virtual void evaluate(const Eigen::MatrixXd& cost_vars, Eigen::VectorXd& costs) const 
+  {
+    int n_task_pars = 0;
+    Eigen::MatrixXd task_parameters(cost_vars.rows(),n_task_pars);
+    return evaluate(cost_vars,task_parameters, costs);
+  };
+  
+  /** The cost function which defines the task.
+   *
+   * \param[in] cost_vars All the variables relevant to computing the cost. These are determined by TaskSolver::performRollouts(). For further information see the section on \ref sec_bbo_task_and_task_solver
+   * \param[in] task_parameters Optional parameters of the task, and thus the cost function.
+   * \param[out] costs The scalar cost for each sample.
+   */
+  virtual void evaluate(const Eigen::MatrixXd& cost_vars, const Eigen::MatrixXd& task_parameters, Eigen::VectorXd& costs) const = 0;
+  
+  /** Save a python script that is able to visualize the rollouts, given the cost-relevant variables
+   *  stored in a file.
+   *  \param[in] directory Directory in which to save the python script
+   *  \return true if saving the script was successful, false otherwise
+   */
+  virtual bool savePerformRolloutsPlotScript(std::string directory) const
+  {
+    return true;
+  }
+  
+  /** Returns a string representation of the object.
+   * \return A string representation of the object.
+   */
+  virtual std::string toString(void) const = 0;
+
+  /** Write to output stream. 
+   *  \param[in] output Output stream to which to write to 
+   *  \param[in] task Task object to write
+   *  \return Output to which the object was written 
+   *
+   *  \remark Calls virtual function Task::toString, which must be implemented by
+   * subclasses: http://stackoverflow.com/questions/4571611/virtual-operator
+   */ 
+  friend std::ostream& operator<<(std::ostream& output, const Task& task) {
+    output << task.toString();
+    return output;
+  }
+  
+private:
+  /** Give boost serialization access to private members. */  
+  friend class boost::serialization::access;
+  
+  /** Serialize class data members to boost archive. 
+   * \param[in] ar Boost archive
+   * \param[in] version Version of the class
+   * See http://www.boost.org/doc/libs/1_55_0/libs/serialization/doc/tutorial.html#simplecase
+   */
+  template<class Archive>
+  void serialize(Archive & ar, const unsigned int version)
+  {
+    // No members to serialize.
+  }
+  
+};
+
+} // namespace DmpBbo
+
+#include <boost/serialization/assume_abstract.hpp>
+/** Don't add version information to archives. */
+BOOST_SERIALIZATION_ASSUME_ABSTRACT(DmpBbo::Task);
+ 
+#include <boost/serialization/level.hpp>
+/** Don't add version information to archives. */
+BOOST_CLASS_IMPLEMENTATION(DmpBbo::Task,boost::serialization::object_serializable);
+
+#endif
+

--- a/src/bbo/TaskSolver.hpp
+++ b/src/bbo/TaskSolver.hpp
@@ -20,7 +20,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
  */
- 
+#define EIGEN2_SUPPORT 
 #ifndef TASK_SOLVER_H
 #define TASK_SOLVER_H
 

--- a/src/bbo/TaskSolver.hpp~
+++ b/src/bbo/TaskSolver.hpp~
@@ -1,0 +1,113 @@
+/**
+ * @file   TaskSolver.hpp
+ * @brief  TaskSolver class header file.
+ * @author Freek Stulp
+ *
+ * This file is part of DmpBbo, a set of libraries and programs for the 
+ * black-box optimization of dynamical movement primitives.
+ * Copyright (C) 2014 Freek Stulp, ENSTA-ParisTech
+ * 
+ * DmpBbo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ * 
+ * DmpBbo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
+#ifndef TASK_SOLVER_H
+#define TASK_SOLVER_H
+
+#include <eigen3/Eigen/Core>
+
+#include <boost/serialization/access.hpp>
+
+namespace DmpBbo {
+
+/** Interface for classes that can perform rollouts.
+ * For further information see the section on \ref sec_bbo_task_and_task_solver
+ */
+class TaskSolver
+{
+public:
+  /** Perform rollouts, i.e. given a set of samples, determine all the variables that are relevant to evaluating the cost function. 
+   * \param[in] samples The samples
+   * \param[out] cost_vars The variables relevant to computing the cost.
+   * \todo Compare to other functions
+   */
+  inline void performRollouts(const Eigen::MatrixXd& samples, Eigen::MatrixXd& cost_vars) const
+  {
+    Eigen::MatrixXd task_parameters(0,0);
+    performRollouts(samples,task_parameters,cost_vars);
+  };
+    
+  /** Perform rollouts, i.e. given a set of samples, determine all the variables that are relevant to evaluating the cost function. 
+   * \param[in] samples The samples
+   * \param[in] task_parameters The parameters of the task
+   * \param[out] cost_vars The variables relevant to computing the cost.
+   * \todo Compare to other functions
+   */
+  virtual void performRollouts(const Eigen::MatrixXd& samples, const Eigen::MatrixXd& task_parameters, Eigen::MatrixXd& cost_vars) const = 0;
+  
+  //void performRollouts(const Eigen::MatrixXd& samples, Eigen::MatrixXd& cost_vars) const 
+  //{
+  //  Eigen::MatrixXd task_parameters(0,0);
+  //  performRollouts(samples,task_parameters,cost_vars);
+  //}
+  
+  // virtual void performRollouts(const std::vector<Eigen::MatrixXd>& samples, const Eigen::MatrixXd& task_parameters, Eigen::MatrixXd& cost_vars) const = 0;
+  
+  /** Returns a string representation of the object.
+   * \return A string representation of the object.
+   */
+  virtual std::string toString(void) const = 0;
+
+  /** Print a TaskSolver to an output stream. 
+   *
+   *  \param[in] output  Output stream to which to write to
+   *  \param[in] task_solver TaskSolver to write
+   *  \return    Output stream
+   *
+   *  \remark Calls virtual function TaskSolver::toString, which must be implemented by
+   * subclasses: http://stackoverflow.com/questions/4571611/virtual-operator
+   */ 
+  friend std::ostream& operator<<(std::ostream& output, const TaskSolver& task_solver) {
+    output << task_solver.toString();
+    return output;
+  }
+  
+private:
+  /** Give boost serialization access to private members. */  
+  friend class boost::serialization::access;
+  
+  /** Serialize class data members to boost archive. 
+   * \param[in] ar Boost archive
+   * \param[in] version Version of the class
+   * See http://www.boost.org/doc/libs/1_55_0/libs/serialization/doc/tutorial.html#simplecase
+   */
+  template<class Archive>
+  void serialize(Archive & ar, const unsigned int version)
+  {
+    // No members to serialize.
+  }
+  
+};
+
+} // namespace DmpBbo
+
+#include <boost/serialization/assume_abstract.hpp>
+/** Don't add version information to archives. */
+BOOST_SERIALIZATION_ASSUME_ABSTRACT(DmpBbo::TaskSolver);
+ 
+#include <boost/serialization/level.hpp>
+/** Don't add version information to archives. */
+BOOST_CLASS_IMPLEMENTATION(DmpBbo::TaskSolver,boost::serialization::object_serializable);
+
+#endif
+

--- a/src/bbo/UpdateSummary.cpp
+++ b/src/bbo/UpdateSummary.cpp
@@ -20,7 +20,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
  */
-
+#define EIGEN2_SUPPORT
 #include "bbo/UpdateSummary.hpp"
 
 #include "bbo/DistributionGaussian.hpp"

--- a/src/bbo/UpdateSummary.cpp~
+++ b/src/bbo/UpdateSummary.cpp~
@@ -1,0 +1,160 @@
+/**
+ * @file   UpdateSummary.hpp
+ * @brief  UpdateSummary class header file.
+ * @author Freek Stulp
+ *
+ * This file is part of DmpBbo, a set of libraries and programs for the 
+ * black-box optimization of dynamical movement primitives.
+ * Copyright (C) 2014 Freek Stulp, ENSTA-ParisTech
+ * 
+ * DmpBbo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ * 
+ * DmpBbo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "bbo/UpdateSummary.hpp"
+
+#include "bbo/DistributionGaussian.hpp"
+#include "dmpbbo_io/EigenFileIO.hpp"
+
+#include <iostream>
+#include <iomanip>
+#include <fstream>
+#include <boost/filesystem.hpp>
+#include <eigen3/Eigen/Core>
+#include <eigen3/Eigen/Eigenvalues> 
+
+using namespace std;
+using namespace Eigen;
+
+namespace DmpBbo {
+
+bool saveToDirectory(const UpdateSummary& summary, string directory, bool overwrite)
+{
+  // Make directory if it doesn't already exist
+  if (!boost::filesystem::exists(directory))
+  {
+    if (!boost::filesystem::create_directories(directory))
+    {
+      cerr << __FILE__ << ":" << __LINE__ << ":";
+      cerr << "Couldn't make directory file '" << directory << "'." << endl;
+      return false;
+    }
+  }
+
+  // Abbreviations to make it fit on one line
+  bool ow = overwrite;
+  string dir = directory;
+  VectorXd cost_eval_vec = VectorXd::Constant(1,summary.cost_eval);
+  
+  if (!saveMatrix(dir, "distribution_mean.txt",  summary.distribution->mean(),  ow)) return false;
+  if (!saveMatrix(dir, "distribution_covar.txt", summary.distribution->covar(), ow)) return false;
+  if (!saveMatrix(dir, "cost_eval.txt",          cost_eval_vec,                 ow)) return false;
+  if (!saveMatrix(dir, "samples.txt",            summary.samples,               ow)) return false;
+  if (!saveMatrix(dir, "costs.txt",              summary.costs,                 ow)) return false;
+  if (!saveMatrix(dir, "weights.txt",            summary.weights,               ow)) return false;
+  if (!saveMatrix(dir, "distribution_new_mean.txt",  summary.distribution_new->mean(),  ow)) return false;
+  if (!saveMatrix(dir, "distribution_new_covar.txt", summary.distribution_new->covar(), ow)) return false;
+  
+  if (summary.cost_vars_eval.size()>0)
+    if (!saveMatrix(dir, "cost_vars_eval.txt",summary.cost_vars_eval, ow)) return false;
+  if (summary.cost_vars.size()>0)
+    if (!saveMatrix(dir, "cost_vars.txt",summary.cost_vars, ow)) return false;
+  
+  return true;
+  
+}
+
+bool saveToDirectory(const vector<UpdateSummary>& update_summaries, std::string directory, bool overwrite, bool only_learning_curve)
+{
+  
+  // Save the learning curve
+  int n_updates = update_summaries.size();
+  MatrixXd learning_curve(n_updates,3);
+  learning_curve(0,0) = 0; // First evaluation is at 0
+  
+  for (int i_update=0; i_update<n_updates; i_update++)
+  {
+    // Number of samples at which an evaluation was performed.
+    if (i_update>0)
+    {
+      int n_samples = update_summaries[i_update].costs.rows();
+      learning_curve(i_update,0) = learning_curve(i_update-1,0) + n_samples; 
+    }
+    
+    // The cost of the evaluation at this update
+    learning_curve(i_update,1) = update_summaries[i_update].cost_eval;
+    
+    // The largest eigenvalue of the covariance matrix
+    MatrixXd eigen_values = update_summaries[i_update].distribution->covar().eigenvalues().real();
+    learning_curve(i_update,2) = sqrt(eigen_values.maxCoeff());
+    
+  }
+
+  if (!saveMatrix(directory, "learning_curve.txt", learning_curve, overwrite))
+    return false;
+    
+  if (!only_learning_curve)
+  {
+    // Save all the information in the update summaries
+    for (int i_update=0; i_update<n_updates; i_update++)
+    {
+      stringstream stream;
+      stream << directory << "/update" << setw(5) << setfill('0') << i_update+1 << "/";
+      if (!saveToDirectory(update_summaries[i_update], stream.str(),overwrite))
+        return false;
+    }
+  }
+  return true;
+}
+
+bool saveToDirectoryNewUpdate(const UpdateSummary& update_summary, std::string directory)
+{
+
+  // Make directory if it doesn't already exist
+  if (!boost::filesystem::exists(directory))
+  {
+    if (!boost::filesystem::create_directories(directory))
+    {
+      cerr << __FILE__ << ":" << __LINE__ << ":";
+      cerr << "Couldn't make directory file '" << directory << "'." << endl;
+      return false;
+    }
+    // Directory didn't exist yet, so this must be the first update.
+    directory += "/update00001/";
+    bool overwrite=true;
+    return saveToDirectory(update_summary,directory,overwrite);
+  }
+  
+  // Find the directory with the highest update
+  // todo: this can probably be done more efficiently with boost::filesystem somehow
+  int MAX_UPDATE = 99999; // Cannot store more in %05d format
+  int i_update=1;
+  while (i_update<MAX_UPDATE)
+  {
+    stringstream stream;
+    stream << directory << "/update" << setw(5) << setfill('0') << i_update << "/";
+    string directory_update = stream.str();
+    if (!boost::filesystem::exists(directory_update))
+    {
+      // Found a directory that doesn't exist yet!
+      bool overwrite=true;
+      return saveToDirectory(update_summary,directory_update,overwrite);
+    }
+    i_update++;
+  }
+  
+  std::cerr << "Sorry, directory " << directory << " is already full with update subdirectories." << std::endl;
+  return false;
+}
+
+}

--- a/src/bbo/UpdateSummary.cpp~
+++ b/src/bbo/UpdateSummary.cpp~
@@ -20,7 +20,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
  */
-
+#define EIGEN2_SUPPORT
 #include "bbo/UpdateSummary.hpp"
 
 #include "bbo/DistributionGaussian.hpp"

--- a/src/bbo/UpdateSummary.hpp
+++ b/src/bbo/UpdateSummary.hpp
@@ -20,7 +20,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
  */
-
+#define EIGEN2_SUPPORT
 #ifndef UPDATESUMMARY_H
 #define UPDATESUMMARY_H   
 

--- a/src/bbo/UpdateSummary.hpp
+++ b/src/bbo/UpdateSummary.hpp
@@ -81,7 +81,7 @@ bool saveToDirectory(const UpdateSummary& update_summary, std::string directory,
  * \param[in] only_learning_curve Save only the learning curve (default: false)
  * \return true if saving the UpdateSummary was successful, false otherwise
  */
-bool saveToDirectory(const std::vector<UpdateSummary>& update_summaries, std::string directory, bool overwrite=false, bool only_learning_curve=false);
+bool saveToDirectory(const std::vector<UpdateSummary>& update_summaries, std::string directory, bool overwrite=false, bool only_learning_curve=false, bool stack_updates=false);
 
 /**
  * Save an update summary to a directory.

--- a/src/bbo/UpdateSummary.hpp~
+++ b/src/bbo/UpdateSummary.hpp~
@@ -20,7 +20,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
  */
-
+#define EIGEN2_SUPPORT
 #ifndef UPDATESUMMARY_H
 #define UPDATESUMMARY_H   
 

--- a/src/bbo/UpdateSummary.hpp~
+++ b/src/bbo/UpdateSummary.hpp~
@@ -1,0 +1,131 @@
+/**
+ * @file   UpdateSummary.hpp
+ * @brief  UpdateSummary class header file.
+ * @author Freek Stulp
+ *
+ * This file is part of DmpBbo, a set of libraries and programs for the 
+ * black-box optimization of dynamical movement primitives.
+ * Copyright (C) 2014 Freek Stulp, ENSTA-ParisTech
+ * 
+ * DmpBbo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ * 
+ * DmpBbo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef UPDATESUMMARY_H
+#define UPDATESUMMARY_H   
+
+#include <string>
+#include <vector>
+#include <eigen3/Eigen/Core>
+
+#include <boost/serialization/nvp.hpp>
+
+namespace DmpBbo {
+  
+// Forward declaration
+class DistributionGaussian;
+
+// POD class, http://en.wikipedia.org/wiki/Plain_old_data_structure
+/** POD class for storing the information relevant to a distribution update. 
+ * Used for logging purposes.
+ * This is a "plain old data" class, i.e. all member variables are public
+ */
+class UpdateSummary {
+public:
+  /** Distribution before update. */
+  DistributionGaussian* distribution;
+  /** Samples in the epoch. */
+  Eigen::MatrixXd samples;
+  /** Cost of the evaluation sample */
+  double cost_eval;
+  /** Costs of the samples in the epoch. */
+  Eigen::VectorXd costs;
+  /** Weights of the samples in the epoch, computed from their costs. */
+  Eigen::MatrixXd weights;
+  /** Distribution after the update. */
+  DistributionGaussian* distribution_new;
+  
+  /** The cost-relevant variables. Only used when Task/TaskSolver approach is used.  */
+  Eigen::MatrixXd cost_vars;
+  /** The cost-relevant variables for the evaluation. 
+      Only used when Task/TaskSolver approach is used.  */
+  Eigen::MatrixXd cost_vars_eval;
+  
+};
+
+/**
+ * Save an update summary to a directory
+ * \param[in] update_summary Object to write
+ * \param[in] directory Directory to which to write object
+ * \param[in] overwrite Overwrite existing files in the directory above (default: false)
+ * \return true if saving the UpdateSummary was successful, false otherwise
+ */
+bool saveToDirectory(const UpdateSummary& update_summary, std::string directory, bool overwrite=false);
+
+
+/**
+ * Save a vector of update summaries to a directory
+ * \param[in] update_summary Object to write
+ * \param[in] directory Directory to which to write object
+ * \param[in] overwrite Overwrite existing files in the directory above (default: false)
+ * \param[in] only_learning_curve Save only the learning curve (default: false)
+ * \return true if saving the UpdateSummary was successful, false otherwise
+ */
+bool saveToDirectory(const std::vector<UpdateSummary>& update_summaries, std::string directory, bool overwrite=false, bool only_learning_curve=false);
+
+/**
+ * Save an update summary to a directory.
+ * This version searches directory for subdirectories updateN and writes the data into a new 
+ * directory updateN+1 (the actual format is update%05d). E.g. if there are directories:
+ * update00000, update00001, and update00002, this function will write to update00003
+ * \param[in] update_summary Object to write
+ * \param[in] directory Directory to which to write object
+ * \return true if saving the UpdateSummary was successful, false otherwise
+ */
+bool saveToDirectoryNewUpdate(const UpdateSummary& update_summary, std::string directory);
+
+}
+
+
+/** Serialization function for boost::serialization. */
+namespace boost {
+namespace serialization {
+
+/** Serialize class data members to boost archive. 
+ * \param[in] ar Boost archive
+ * \param[in] update_summary UpdateSummary object to serialize.
+ * \param[in] version Version of the class
+ * See http://www.boost.org/doc/libs/1_55_0/libs/serialization/doc/tutorial.html#simplecase
+ */
+template<class Archive>
+void serialize(Archive & ar, DmpBbo::UpdateSummary& update_summary, const unsigned int version)
+{
+  ar & BOOST_SERIALIZATION_NVP(update_summary.distribution);
+  ar & BOOST_SERIALIZATION_NVP(update_summary.samples);
+  ar & BOOST_SERIALIZATION_NVP(update_summary.cost_eval);
+  ar & BOOST_SERIALIZATION_NVP(update_summary.costs);
+  ar & BOOST_SERIALIZATION_NVP(update_summary.weights);
+  ar & BOOST_SERIALIZATION_NVP(update_summary.distribution_new);
+  ar & BOOST_SERIALIZATION_NVP(update_summary.cost_vars);
+  ar & BOOST_SERIALIZATION_NVP(update_summary.cost_vars_eval);
+}
+
+} // namespace serialization
+} // namespace boost
+
+
+/** Don't add version information to archives. */
+BOOST_CLASS_IMPLEMENTATION(DmpBbo::UpdateSummary,boost::serialization::object_serializable);
+
+#endif
+

--- a/src/bbo/Updater.hpp
+++ b/src/bbo/Updater.hpp
@@ -21,7 +21,7 @@
  * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
  */
  
-
+#define EIGEN2_SUPPORT
 #ifndef UPDATER_H
 #define UPDATER_H
 

--- a/src/bbo/Updater.hpp~
+++ b/src/bbo/Updater.hpp~
@@ -1,0 +1,140 @@
+/**
+ * @file   Updater.hpp
+ * @brief  Updater class header file.
+ * @author Freek Stulp
+ *
+ * This file is part of DmpBbo, a set of libraries and programs for the 
+ * black-box optimization of dynamical movement primitives.
+ * Copyright (C) 2014 Freek Stulp, ENSTA-ParisTech
+ * 
+ * DmpBbo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ * 
+ * DmpBbo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
+
+#ifndef UPDATER_H
+#define UPDATER_H
+
+#include <vector>
+#include <eigen3/Eigen/Core>
+
+#include "bbo/UpdateSummary.hpp"
+#include "bbo/DistributionGaussian.hpp"
+
+#include <boost/serialization/access.hpp>
+
+namespace DmpBbo {
+
+/** Interface for the distribution update step in evolution strategies.
+ *
+ * Evolution strategies implement the following loop:
+\code
+// distribution has been initialized above
+for (int i_update=1; i_update<=n_updates; i_update++)
+  // Sample from distribution
+  samples = distribution->generateSamples(n_samples_per_update);
+  // Perform rollouts for the samples and compute costs
+  costs = cost_function_solver->evaluate(samples);
+  // Update parameters
+  distribution = updater->updateDistribution(distribution, samples, costs);
+}
+\endcode
+ *
+ * The last step (updating the distribution) is implemented by classes inheriting from this Updater
+ * interface.
+ *
+ * \todo Implement << and virtual toString with boost serialization
+ */
+class Updater
+{
+public:
+  
+  /** Update a distribution given the samples and costs of an epoch.
+   * \param[in] distribution Current distribution
+   * \param[in] samples The samples in the epoch (size: n_samples X n_dims)
+   * \param[in] costs Costs of the samples (size: n_samples x 1)
+   * \param[out] weights The weights computed from the costs
+   * \param[out] distribution_new Updated distribution
+   * \param[out] summary An object containing all relevant update information, for logging and debugging purposes.
+   */
+  inline void updateDistribution(const DistributionGaussian& distribution, const Eigen::MatrixXd& samples, const Eigen::VectorXd& costs, Eigen::VectorXd& weights, DistributionGaussian& distribution_new, UpdateSummary& summary) const
+  {
+    summary.distribution = distribution.clone();
+    summary.samples = samples;
+    summary.costs = costs;
+    updateDistribution(distribution, samples, costs, weights, distribution_new);
+    summary.weights = weights;
+    summary.distribution_new = distribution_new.clone();
+  }
+
+  /** Update a distribution given the samples and costs of an epoch.
+   * \param[in] distribution Current distribution
+   * \param[in] samples The samples in the epoch (size: n_samples X n_dims)
+   * \param[in] costs Costs of the samples (size: n_samples x 1)
+   * \param[out] distribution_new Updated distribution
+   */
+  inline void updateDistribution(const DistributionGaussian& distribution, const Eigen::MatrixXd& samples, const Eigen::VectorXd& costs, DistributionGaussian& distribution_new) const {
+    Eigen::VectorXd weights;
+    updateDistribution(distribution, samples, costs, weights, distribution_new);     
+  }
+  
+  /** Update a distribution given the samples and costs of an epoch.
+   * \param[in] distribution Current distribution
+   * \param[in] samples The samples in the epoch (size: n_samples X n_dims)
+   * \param[in] costs Costs of the samples (size: n_samples x 1)
+   * \param[out] distribution_new Updated distribution
+   * \param[out] summary An object containing all relevant update information, for logging and debugging purposes.
+   */
+  inline void updateDistribution(const DistributionGaussian& distribution, const Eigen::MatrixXd& samples, const Eigen::VectorXd& costs, DistributionGaussian& distribution_new, UpdateSummary& summary) const 
+  {
+    Eigen::VectorXd weights;
+    updateDistribution(distribution, samples, costs, weights, distribution_new, summary);     
+  }
+  
+  /** Update a distribution given the samples and costs of an epoch.
+   * \param[in] distribution Current distribution
+   * \param[in] samples The samples in the epoch (size: n_samples X n_dims)
+   * \param[in] costs Costs of the samples (size: n_samples x 1)
+   * \param[out] weights The weights computed from the costs
+   * \param[out] distribution_new Updated distribution
+   */
+  virtual void updateDistribution(const DistributionGaussian& distribution, const Eigen::MatrixXd& samples, const Eigen::VectorXd& costs, Eigen::VectorXd& weights, DistributionGaussian& distribution_new) const = 0;
+  
+private:
+  /** Give boost serialization access to private members. */  
+  friend class boost::serialization::access;
+  
+  /** Serialize class data members to boost archive. 
+   * \param[in] ar Boost archive
+   * \param[in] version Version of the class
+   * See http://www.boost.org/doc/libs/1_55_0/libs/serialization/doc/tutorial.html#simplecase
+   */
+  template<class Archive>
+  void serialize(Archive & ar, const unsigned int version)
+  {
+    // No members to serialize.
+  }
+  
+};
+
+} // namespace DmpBbo
+
+#include <boost/serialization/assume_abstract.hpp>
+/** Don't add version information to archives. */
+BOOST_SERIALIZATION_ASSUME_ABSTRACT(DmpBbo::Updater);
+ 
+#include <boost/serialization/level.hpp>
+/** Don't add version information to archives. */
+BOOST_CLASS_IMPLEMENTATION(DmpBbo::Updater,boost::serialization::object_serializable);
+
+#endif

--- a/src/bbo/runEvolutionaryOptimization.cpp
+++ b/src/bbo/runEvolutionaryOptimization.cpp
@@ -20,7 +20,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
  */
-
+#define EIGEN2_SUPPORT
 #include "bbo/runEvolutionaryOptimization.hpp"
 
 #include <iomanip>

--- a/src/bbo/runEvolutionaryOptimization.cpp~
+++ b/src/bbo/runEvolutionaryOptimization.cpp~
@@ -1,0 +1,206 @@
+/**
+ * @file runEvolutionaryOptimization.cpp
+ * @brief  Source file for function to run an evolutionary optimization process.
+ * @author Freek Stulp
+ *
+ * This file is part of DmpBbo, a set of libraries and programs for the 
+ * black-box optimization of dynamical movement primitives.
+ * Copyright (C) 2014 Freek Stulp, ENSTA-ParisTech
+ * 
+ * DmpBbo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ * 
+ * DmpBbo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "bbo/runEvolutionaryOptimization.hpp"
+
+#include <iomanip>
+#include <fstream>
+#include <boost/filesystem.hpp>
+#include <eigen3/Eigen/Core>
+
+#include "bbo/DistributionGaussian.hpp"
+#include "bbo/Updater.hpp"
+#include "bbo/UpdateSummary.hpp"
+#include "bbo/CostFunction.hpp"
+#include "bbo/Task.hpp"
+#include "bbo/TaskSolver.hpp"
+#include "bbo/ExperimentBBO.hpp"
+
+#include "dmpbbo_io/EigenFileIO.hpp"
+
+
+
+
+using namespace std;
+using namespace Eigen;
+
+namespace DmpBbo {
+  
+void runEvolutionaryOptimization(
+  const CostFunction* const cost_function, 
+  const DistributionGaussian* const initial_distribution, 
+  const Updater* const updater, 
+  int n_updates, 
+  int n_samples_per_update, 
+  string save_directory,
+  bool overwrite,
+  bool only_learning_curve)
+{
+
+  // Some variables
+  MatrixXd samples;
+  VectorXd costs, cost_eval;
+  // Bookkeeping
+  vector<UpdateSummary> update_summaries;
+  UpdateSummary update_summary;
+  
+  if (save_directory.empty()) 
+    cout << "init  =  " << "  distribution=" << *initial_distribution;
+  
+  // Optimization loop
+  DistributionGaussian* distribution = initial_distribution->clone();
+  for (int i_update=0; i_update<n_updates; i_update++)
+  {
+    // 0. Get cost of current distribution mean
+    cost_function->evaluate(distribution->mean().transpose(),cost_eval);
+    
+    // 1. Sample from distribution
+    distribution->generateSamples(n_samples_per_update, samples);
+
+    // 2. Evaluate the samples
+    cost_function->evaluate(samples,costs);
+  
+    // 3. Update parameters
+    updater->updateDistribution(*distribution, samples, costs, *distribution, update_summary);
+      
+    
+    // Some output and/or saving to file (if "directory" is set)
+    if (save_directory.empty()) 
+    {
+      cout << "\t cost_eval=" << cost_eval << endl << i_update+1 << "  " << *distribution;
+    }
+    else
+    {
+      update_summary.cost_eval = cost_eval[0];
+      update_summaries.push_back(update_summary);
+    }
+  }
+  
+  // Save update summaries to file, if necessary
+  if (!save_directory.empty())
+    saveToDirectory(update_summaries,save_directory,overwrite,only_learning_curve);
+
+}
+
+// This function could have been integrated with the above. But I preferred to duplicate a bit of
+// code so that the difference between running an optimziation with a CostFunction or
+// Task/TaskSolver is more apparent.
+void runEvolutionaryOptimization(
+  const Task* const task, 
+  const TaskSolver* const task_solver, 
+  const DistributionGaussian* const initial_distribution, 
+  const Updater* const updater, 
+  int n_updates, 
+  int n_samples_per_update, 
+  string save_directory, 
+  bool overwrite,
+  bool only_learning_curve)
+{
+  // Some variables
+  MatrixXd samples;
+  MatrixXd cost_vars, cost_vars_eval;
+  VectorXd costs, cost_eval;
+  // Bookkeeping
+  vector<UpdateSummary> update_summaries;
+  UpdateSummary update_summary;
+  
+  if (save_directory.empty()) 
+    cout << "init  =  " << "  distribution=" << *initial_distribution;
+  
+  // Optimization loop
+  DistributionGaussian* distribution = initial_distribution->clone();
+  for (int i_update=0; i_update<n_updates; i_update++)
+  {
+    // 0. Get cost of current distribution mean
+    task_solver->performRollouts(distribution->mean().transpose(),cost_vars_eval);
+    task->evaluate(cost_vars_eval,cost_eval);
+    
+    // 1. Sample from distribution
+    distribution->generateSamples(n_samples_per_update, samples);
+
+    // 2A. Perform the roll-outs
+    task_solver->performRollouts(samples,cost_vars);
+  
+    // 2B. Evaluate the samples
+    task->evaluate(cost_vars,costs);
+  
+    // 3. Update parameters
+    updater->updateDistribution(*distribution, samples, costs, *distribution, update_summary);
+      
+    
+    // Some output and/or saving to file (if "directory" is set)
+    if (save_directory.empty()) 
+    {
+      cout << "\t cost_eval=" << cost_eval << endl << i_update+1 << "  " << *distribution;
+    }
+    else
+    {
+      update_summary.cost_eval = cost_eval[0];
+      update_summary.cost_vars_eval = cost_vars_eval;
+      update_summary.cost_vars = cost_vars;
+      update_summaries.push_back(update_summary);
+    }
+  }
+  
+  // Save update summaries to file, if necessary
+  if (!save_directory.empty())
+  {
+    saveToDirectory(update_summaries,save_directory,overwrite,only_learning_curve);
+    // If you store only the learning curve, no need to save the script to visualize rollouts    
+    if (!only_learning_curve)
+      task->savePerformRolloutsPlotScript(save_directory);
+  }
+
+}
+
+void runEvolutionaryOptimization(ExperimentBBO* experiment, string save_directory, bool overwrite,   bool only_learning_curve)
+{
+ if (experiment->cost_function!=NULL)
+ {
+   runEvolutionaryOptimization(
+     experiment->cost_function,
+     experiment->initial_distribution,
+     experiment->updater, 
+     experiment->n_updates, 
+     experiment->n_samples_per_update, 
+     save_directory,
+     overwrite,
+     only_learning_curve);
+ }
+ else
+ {
+   runEvolutionaryOptimization(
+     experiment->task,
+     experiment->task_solver,
+     experiment->initial_distribution,
+     experiment->updater, 
+     experiment->n_updates, 
+     experiment->n_samples_per_update, 
+     save_directory,
+     overwrite,
+     only_learning_curve);
+ }
+}
+
+
+}

--- a/src/bbo/tests/testDistributionGaussian.cpp
+++ b/src/bbo/tests/testDistributionGaussian.cpp
@@ -61,21 +61,17 @@ int main(int n_args, char* args[])
   cout << "________________\nsamples distribution 1 =\n" << samples << endl;
   distribution2.generateSamples(n_samples, samples);
   cout << "________________\nsamples distribution 2 =\n" << samples << endl;
-
   
   
-  
-  n_samples = 1000;
-  distribution1.generateSamples(n_samples, samples);
-  
-  cout << "distribution = " << distribution1 << endl;
-
   if (directory.empty())
   {
-    cout << "________________\nsamples =\n" << samples << endl;
+    //cout << "________________\nsamples =\n" << samples << endl;
   } 
   else 
   {
+    n_samples = 1000;
+    distribution1.generateSamples(n_samples, samples);
+  
     ofstream outfile;
     string filename = directory+"/samples.txt";
     outfile.open(filename.c_str()); 
@@ -105,10 +101,12 @@ int main(int n_args, char* args[])
   ia >> BOOST_SERIALIZATION_NVP(distribution_out);
   ifs.close();
   
+  
   cout << "___________________________________________" << endl;
   cout << distribution1 << endl;
   cout << distribution_out << endl;
-  
+  distribution_out.generateSamples(10, samples);
+  cout << samples << endl;
 }
 
 

--- a/src/dmp/Dmp.cpp
+++ b/src/dmp/Dmp.cpp
@@ -3,20 +3,20 @@
  * @brief  Dmp class source file.
  * @author Freek Stulp
  *
- * This file is part of DmpBbo, a set of libraries and programs for the 
+ * This file is part of DmpBbo, a set of libraries and programs for the
  * black-box optimization of dynamical movement primitives.
  * Copyright (C) 2014 Freek Stulp, ENSTA-ParisTech
- * 
+ *
  * DmpBbo is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 2 of the License, or
  * (at your option) any later version.
- * 
+ *
  * DmpBbo is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -69,22 +69,22 @@ namespace DmpBbo {
 
 boost::mt19937 Dmp::rng = boost::mt19937(getpid() + time(0));
 
-Dmp::Dmp(double tau, VectorXd y_init, VectorXd y_attr, 
+Dmp::Dmp(double tau, VectorXd y_init, VectorXd y_attr,
          vector<FunctionApproximator*> function_approximators,
-         double alpha_spring_damper, 
+         double alpha_spring_damper,
          DynamicalSystem* goal_system,
-         DynamicalSystem* phase_system, 
+         DynamicalSystem* phase_system,
          DynamicalSystem* gating_system)
   : DynamicalSystem(1, tau, y_init, y_attr, "name"),
   goal_system_(goal_system),
-  phase_system_(phase_system), gating_system_(gating_system) 
+  phase_system_(phase_system), gating_system_(gating_system)
 {
   initSubSystems(alpha_spring_damper, goal_system, phase_system, gating_system);
   initFunctionApproximators(function_approximators);
 }
 
-  
-Dmp::Dmp(int n_dims_dmp, vector<FunctionApproximator*> function_approximators, 
+
+Dmp::Dmp(int n_dims_dmp, vector<FunctionApproximator*> function_approximators,
    double alpha_spring_damper, DynamicalSystem* goal_system,
    DynamicalSystem* phase_system, DynamicalSystem* gating_system)
   : DynamicalSystem(1, 1.0, VectorXd::Zero(n_dims_dmp), VectorXd::Ones(n_dims_dmp), "name"),
@@ -94,18 +94,18 @@ Dmp::Dmp(int n_dims_dmp, vector<FunctionApproximator*> function_approximators,
   initSubSystems(alpha_spring_damper, goal_system, phase_system, gating_system);
   initFunctionApproximators(function_approximators);
 }
-    
-Dmp::Dmp(double tau, VectorXd y_init, VectorXd y_attr, 
-         vector<FunctionApproximator*> function_approximators, 
+
+Dmp::Dmp(double tau, VectorXd y_init, VectorXd y_attr,
+         vector<FunctionApproximator*> function_approximators,
          DmpType dmp_type)
   : DynamicalSystem(1, tau, y_init, y_attr, "name")
-{  
+{
   initSubSystems(dmp_type);
   initFunctionApproximators(function_approximators);
 }
-  
-Dmp::Dmp(int n_dims_dmp, 
-         vector<FunctionApproximator*> function_approximators, 
+
+Dmp::Dmp(int n_dims_dmp,
+         vector<FunctionApproximator*> function_approximators,
          DmpType dmp_type)
   : DynamicalSystem(1, 1.0, VectorXd::Zero(n_dims_dmp), VectorXd::Ones(n_dims_dmp), "name")
 {
@@ -113,27 +113,27 @@ Dmp::Dmp(int n_dims_dmp,
   initFunctionApproximators(function_approximators);
 }
 
-Dmp::Dmp(double tau, VectorXd y_init, VectorXd y_attr, double alpha_spring_damper, DynamicalSystem* goal_system) 
+Dmp::Dmp(double tau, VectorXd y_init, VectorXd y_attr, double alpha_spring_damper, DynamicalSystem* goal_system)
   : DynamicalSystem(1, tau, y_init, y_attr, "name")
 {
-  
+
   VectorXd one_1 = VectorXd::Ones(1);
   VectorXd one_0 = VectorXd::Zero(1);
   DynamicalSystem* phase_system  = new ExponentialSystem(tau,one_1,one_0,4);
-  DynamicalSystem* gating_system = new ExponentialSystem(tau,one_1,one_0,4); 
+  DynamicalSystem* gating_system = new ExponentialSystem(tau,one_1,one_0,4);
   initSubSystems(alpha_spring_damper, goal_system, phase_system, gating_system);
 
-  vector<FunctionApproximator*> function_approximators(y_init.size());    
+  vector<FunctionApproximator*> function_approximators(y_init.size());
   for (int dd=0; dd<y_init.size(); dd++)
     function_approximators[dd] = NULL;
-  initFunctionApproximators(function_approximators);  
+  initFunctionApproximators(function_approximators);
 }
 
 void Dmp::initSubSystems(DmpType dmp_type)
 {
   VectorXd one_1 = VectorXd::Ones(1);
   VectorXd one_0 = VectorXd::Zero(1);
-  
+
   DynamicalSystem *goal_system=NULL;
   DynamicalSystem *phase_system=NULL;
   DynamicalSystem *gating_system=NULL;
@@ -141,18 +141,18 @@ void Dmp::initSubSystems(DmpType dmp_type)
   {
     goal_system   = NULL;
     phase_system  = new ExponentialSystem(tau(),one_1,one_0,4);
-    gating_system = new ExponentialSystem(tau(),one_1,one_0,4); 
-  }                                                          
+    gating_system = new ExponentialSystem(tau(),one_1,one_0,4);
+  }
   else if (dmp_type==KULVICIUS_2012_JOINING || dmp_type==COUNTDOWN_2013)
   {
     goal_system   = new ExponentialSystem(tau(),initial_state(),attractor_state(),15);
-    gating_system = new SigmoidSystem(tau(),one_1,-40,0.9*tau()); 
-    bool count_down = (dmp_type==COUNTDOWN_2013);    
+    gating_system = new SigmoidSystem(tau(),one_1,40,0.7*tau());
+    bool count_down = (dmp_type==COUNTDOWN_2013);
     phase_system  = new TimeSystem(tau(),count_down);
   }
-  
+
   double alpha_spring_damper = 20;
-  
+
   initSubSystems(alpha_spring_damper, goal_system, phase_system, gating_system);
 }
 
@@ -162,8 +162,8 @@ void Dmp::initSubSystems(double alpha_spring_damper, DynamicalSystem* goal_syste
 
   // Make room for the subsystems
   set_dim(3*dim_orig()+2);
-    
-  spring_system_ = new SpringDamperSystem(tau(),initial_state(),attractor_state(),alpha_spring_damper);  
+
+  spring_system_ = new SpringDamperSystem(tau(),initial_state(),attractor_state(),alpha_spring_damper);
   spring_system_->set_name(name()+"_spring-damper");
   analytical_solution_perturber_ = NULL; // Do not perturb spring-damper as default
 
@@ -186,20 +186,20 @@ void Dmp::initSubSystems(double alpha_spring_damper, DynamicalSystem* goal_syste
 
 void Dmp::set_damping_coefficient(double damping_coefficient)
 {
-  spring_system_->set_damping_coefficient(damping_coefficient); 
+  spring_system_->set_damping_coefficient(damping_coefficient);
 }
 void Dmp::set_spring_constant(double spring_constant) {
-  spring_system_->set_spring_constant(spring_constant); 
+  spring_system_->set_spring_constant(spring_constant);
 }
-  
+
 
 void Dmp::initFunctionApproximators(vector<FunctionApproximator*> function_approximators)
 {
   if (function_approximators.empty())
     return;
-  
+
   assert(dim_orig()==(int)function_approximators.size());
-  
+
   function_approximators_ = vector<FunctionApproximator*>(function_approximators.size());
   for (unsigned int dd=0; dd<function_approximators.size(); dd++)
   {
@@ -213,7 +213,7 @@ void Dmp::initFunctionApproximators(vector<FunctionApproximator*> function_appro
 
 Dmp::~Dmp(void)
 {
-  delete goal_system_;   
+  delete goal_system_;
   delete spring_system_;
   delete phase_system_;
   delete gating_system_;
@@ -225,7 +225,7 @@ Dmp* Dmp::clone(void) const {
   vector<FunctionApproximator*> function_approximators;
   for (unsigned int ff=0; ff<function_approximators_.size(); ff++)
     function_approximators.push_back(function_approximators_[ff]->clone());
-  
+
   return new Dmp(tau(), initial_state(), attractor_state(), function_approximators,
    spring_system_->damping_coefficient(), goal_system_->clone(),
    phase_system_->clone(), gating_system_->clone());
@@ -236,10 +236,10 @@ void Dmp::integrateStart(Ref<VectorXd> x, Ref<VectorXd> xd) const
 {
   assert(x.size()==dim());
   assert(xd.size()==dim());
-  
-  x.fill(0);  
-  xd.fill(0);  
-  
+
+  x.fill(0);
+  xd.fill(0);
+
   // Start integrating goal system if it exists
   if (goal_system_==NULL)
   {
@@ -252,11 +252,11 @@ void Dmp::integrateStart(Ref<VectorXd> x, Ref<VectorXd> xd) const
     // Goal system exists. Start integrating it.
     goal_system_->integrateStart(x.GOAL,xd.GOAL);
   }
-  
-    
+
+
   // Set the attractor state of the spring system
   spring_system_->set_attractor_state(x.GOAL);
-  
+
   // Start integrating all futher subsystems
   spring_system_->integrateStart(x.SPRING, xd.SPRING);
   phase_system_->integrateStart(  x.PHASE,  xd.PHASE);
@@ -264,7 +264,7 @@ void Dmp::integrateStart(Ref<VectorXd> x, Ref<VectorXd> xd) const
 
   // Add rates of change
   differentialEquation(x,xd);
-  
+
 }
 
 /*
@@ -273,11 +273,11 @@ bool Dmp::isTrained(void) const
   for (int i_dim=0; i_dim<dim_orig(); i_dim++)
     if (function_approximators_[i_dim]!=NULL)
       return false;
-    
+
   for (int i_dim=0; i_dim<dim_orig(); i_dim++)
-    if (function_approximators_[i_dim]->isTrained()) 
+    if (function_approximators_[i_dim]->isTrained())
       return false;
-    
+
   return true;
 }
 */
@@ -287,13 +287,13 @@ void Dmp::computeFunctionApproximatorOutput(const MatrixXd& phase_state, MatrixX
   int T = phase_state.rows();
   fa_output.resize(T,dim_orig());
   fa_output.fill(0.0);
-  
+
   MatrixXd output(T,1);
   for (int i_dim=0; i_dim<dim_orig(); i_dim++)
   {
     if (function_approximators_[i_dim]!=NULL)
     {
-      if (function_approximators_[i_dim]->isTrained()) 
+      if (function_approximators_[i_dim]->isTrained())
       {
         function_approximators_[i_dim]->predict(phase_state,output);
         fa_output.col(i_dim) = output;
@@ -304,7 +304,7 @@ void Dmp::computeFunctionApproximatorOutput(const MatrixXd& phase_state, MatrixX
 
 void Dmp::differentialEquation(const VectorXd& x, Ref<VectorXd> xd) const
 {
-  
+
   if (goal_system_==NULL)
   {
     // If there is no dynamical system for the delayed goal, the goal is
@@ -312,7 +312,7 @@ void Dmp::differentialEquation(const VectorXd& x, Ref<VectorXd> xd) const
     spring_system_->set_attractor_state(attractor_state());
     // with zero change
     xd.GOAL.fill(0);
-  } 
+  }
   else
   {
     // Integrate goal system and get current goal state
@@ -320,14 +320,14 @@ void Dmp::differentialEquation(const VectorXd& x, Ref<VectorXd> xd) const
     goal_system_->differentialEquation(x.GOAL, xd.GOAL);
     // The goal state is the attractor state of the spring-damper system
     spring_system_->set_attractor_state(x.GOAL);
-        
+
   }
 
   // Integrate spring damper system
   // Forcing term is added to spring_state later
   spring_system_->differentialEquation(x.SPRING, xd.SPRING);
 
-  
+
   // Non-linear forcing term
   phase_system_->differentialEquation(x.PHASE, xd.PHASE);
   gating_system_->differentialEquation(x.GATING, xd.GATING);
@@ -335,8 +335,8 @@ void Dmp::differentialEquation(const VectorXd& x, Ref<VectorXd> xd) const
   MatrixXd phase_state(1,1);
   phase_state = x.PHASE;
   MatrixXd fa_output(1,dim_orig());
-  computeFunctionApproximatorOutput(phase_state, fa_output); 
-  
+  computeFunctionApproximatorOutput(phase_state, fa_output);
+
   int t0 = 0;
   double gating = (x.GATING)[0];
   VectorXd g_minus_y0 = (attractor_state()-initial_state()).transpose();
@@ -350,7 +350,7 @@ void Dmp::differentialEquation(const VectorXd& x, Ref<VectorXd> xd) const
 
 void Dmp::statesAsTrajectory(const MatrixXd& x_in, const MatrixXd& xd_in, MatrixXd& y_out, MatrixXd& yd_out, MatrixXd& ydd_out) const
 {
-  int n_time_steps = x_in.rows(); 
+  int n_time_steps = x_in.rows();
   y_out  = x_in.SPRINGM_Y(n_time_steps);
   yd_out = xd_in.SPRINGM_Y(n_time_steps);
   ydd_out = xd_in.SPRINGM_Z(n_time_steps)/tau();
@@ -382,28 +382,28 @@ void Dmp::statesAsTrajectory(const VectorXd& ts, const MatrixXd& x_in, const Mat
     // ydd_out (see function above)
     xd_in.SPRINGM_Z(n_time_steps)/tau()
   );
-  
+
   trajectory = new_trajectory;
-  
+
 }
 
 void Dmp::analyticalSolution(const VectorXd& ts, MatrixXd& xs, MatrixXd& xds, Eigen::MatrixXd& forcing_terms, Eigen::MatrixXd& fa_outputs) const
 {
   int n_time_steps = ts.size();
   assert(n_time_steps>0);
-  
+
   // Usually, we expect xs and xds to be of size T X dim(), so we resize to that. However, if the
-  // input matrices were of size dim() X T, we return the matrices of that size by doing a 
+  // input matrices were of size dim() X T, we return the matrices of that size by doing a
   // transposeInPlace at the end. That way, the user can also request dim() X T sized matrices.
   bool caller_expects_transposed = (xs.rows()==dim() && xs.cols()==n_time_steps);
-  
+
   // INTEGRATE SYSTEMS ANALYTICALLY AS MUCH AS POSSIBLE
 
   // Integrate phase
   MatrixXd xs_phase;
   MatrixXd xds_phase;
   phase_system_->analyticalSolution(ts,xs_phase,xds_phase);
-  
+
   // Compute gating term
   MatrixXd xs_gating;
   MatrixXd xds_gating;
@@ -418,17 +418,17 @@ void Dmp::analyticalSolution(const VectorXd& ts, MatrixXd& xs, MatrixXd& xds, Ei
   MatrixXd xs_gating_rep = xs_gating.replicate(1,fa_outputs.cols());
   MatrixXd g_minus_y0_rep = (attractor_state()-initial_state()).transpose().replicate(n_time_steps,1);
   forcing_terms = fa_outputs.array()*xs_gating_rep.array(); // todo *g_minus_y0_rep.array();
-  
+
   MatrixXd xs_goal, xds_goal;
   // Get current delayed goal
   if (goal_system_==NULL)
   {
     // If there is no dynamical system for the delayed goal, the goal is
-    // simply the attractor state               
+    // simply the attractor state
     xs_goal  = attractor_state().transpose().replicate(n_time_steps,1);
     // with zero change
     xds_goal = MatrixXd::Zero(n_time_steps,dim_orig());
-  } 
+  }
   else
   {
     // Integrate goal system and get current goal state
@@ -439,21 +439,21 @@ void Dmp::analyticalSolution(const VectorXd& ts, MatrixXd& xs, MatrixXd& xds, Ei
   xds.resize(n_time_steps,dim());
 
   int T = n_time_steps;
-    
+
   xs.GOALM(T) = xs_goal;     xds.GOALM(T) = xds_goal;
   xs.PHASEM(T) = xs_phase;   xds.PHASEM(T) = xds_phase;
   xs.GATINGM(T) = xs_gating; xds.GATINGM(T) = xds_gating;
 
-  
+
   // THE REST CANNOT BE DONE ANALYTICALLY
-  
+
   // Reset the dynamical system, and get the first state
   double damping = spring_system_->damping_coefficient();
   SpringDamperSystem localspring_system_(tau(),initial_state(),attractor_state(),damping);
-  
+
   // Set first attractor state
   localspring_system_.set_attractor_state(xs_goal.row(0));
-  
+
   // Start integrating spring damper system
   int dim_spring = localspring_system_.dim();
   VectorXd x_spring(dim_spring), xd_spring(dim_spring); // todo Why are these needed?
@@ -462,35 +462,35 @@ void Dmp::analyticalSolution(const VectorXd& ts, MatrixXd& xs, MatrixXd& xds, Ei
   xs.row(t0).SPRING  = x_spring;
   xds.row(t0).SPRING = xd_spring;
 
-  // Add forcing term to the acceleration of the spring state  
+  // Add forcing term to the acceleration of the spring state
   xds.SPRINGM_Z(1) = xds.SPRINGM_Z(1) + forcing_terms.row(t0)/tau();
-  
+
   for (int tt=1; tt<n_time_steps; tt++)
   {
     double dt = ts[tt]-ts[tt-1];
-    
+
     // Euler integration
     xs.row(tt).SPRING  = xs.row(tt-1).SPRING + dt*xds.row(tt-1).SPRING;
-  
+
     // Set the attractor state of the spring system
     localspring_system_.set_attractor_state(xs.row(tt).GOAL);
 
     // Integrate spring damper system
     localspring_system_.differentialEquation(xs.row(tt).SPRING, xd_spring);
     xds.row(tt).SPRING = xd_spring;
-    
+
     RowVectorXd perturbation = RowVectorXd::Constant(dim_orig(),0.0);
     if (analytical_solution_perturber_!=NULL)
       for (int i_dim=0; i_dim<dim_orig(); i_dim++)
         perturbation(i_dim) = (*analytical_solution_perturber_)();
-      
+
     // Add forcing term to the acceleration of the spring state
     xds.row(tt).SPRING_Z = xds.row(tt).SPRING_Z + forcing_terms.row(tt)/tau() + perturbation;
     // Compute y component from z
     xds.row(tt).SPRING_Y = xs.row(tt).SPRING_Z/tau();
-    
-  } 
-  
+
+  }
+
   if (caller_expects_transposed)
   {
     xs.transposeInPlace();
@@ -502,20 +502,20 @@ void Dmp::computeFunctionApproximatorInputsAndTargets(const Trajectory& trajecto
 {
   int n_time_steps = trajectory.length();
   double dim_data = trajectory.dim();
-  
+
   if (dim_orig()!=dim_data)
   {
     cout << "WARNING: Cannot train " << dim_orig() << "-D DMP with " << dim_data << "-D data. Doing nothing." << endl;
     return;
   }
-  
+
   // Integrate analytically to get goal, gating and phase states
   MatrixXd xs_ana;
   MatrixXd xds_ana;
-  
+
   // Before, we would make clone of the dmp, and integrate it with the tau, and initial/attractor
   // state of the trajectory. However, Thibaut needed to call this from outside the Dmp as well,
-  // with the tau/states of the this object. Therefore, we no longer clone. 
+  // with the tau/states of the this object. Therefore, we no longer clone.
   // Dmp* dmp_clone = static_cast<Dmp*>(this->clone());
   // dmp_clone->set_tau(trajectory.duration());
   // dmp_clone->set_initial_state(trajectory.initial_y());
@@ -525,9 +525,9 @@ void Dmp::computeFunctionApproximatorInputsAndTargets(const Trajectory& trajecto
   MatrixXd xs_goal   = xs_ana.GOALM(n_time_steps);
   MatrixXd xs_gating = xs_ana.GATINGM(n_time_steps);
   MatrixXd xs_phase  = xs_ana.PHASEM(n_time_steps);
-  
+
   fa_inputs_phase = xs_phase;
-  
+
   // Get parameters from the spring-dampers system to compute inverse
   double damping_coefficient = spring_system_->damping_coefficient();
   double spring_constant     = spring_system_->spring_constant();
@@ -539,11 +539,11 @@ void Dmp::computeFunctionApproximatorInputsAndTargets(const Trajectory& trajecto
 
   // Compute inverse
   f_target = tau()*tau()*trajectory.ydds() + (spring_constant*(trajectory.ys()-xs_goal) + damping_coefficient*tau()*trajectory.yds())/mass;
-  
+
   //Factor out gating term
   for (unsigned int dd=0; dd<function_approximators_.size(); dd++)
     f_target.col(dd) = f_target.col(dd).array()/xs_gating.array();
- 
+
 }
 
 void Dmp::train(const Trajectory& trajectory)
@@ -553,19 +553,19 @@ void Dmp::train(const Trajectory& trajectory)
 
 void Dmp::train(const Trajectory& trajectory, string save_directory, bool overwrite)
 {
-  
-  // Set tau, initial_state and attractor_state from the trajectory 
+
+  // Set tau, initial_state and attractor_state from the trajectory
   set_tau(trajectory.duration());
   set_initial_state(trajectory.initial_y());
   set_attractor_state(trajectory.final_y());
-  
+
   VectorXd fa_input_phase;
   MatrixXd f_target;
   computeFunctionApproximatorInputsAndTargets(trajectory, fa_input_phase, f_target);
-  
+
   // Some checks before training function approximators
   assert(!function_approximators_.empty());
-  
+
   for (unsigned int dd=0; dd<function_approximators_.size(); dd++)
   {
     // This is just boring stuff to figure out if and where to store the results of training
@@ -577,7 +577,7 @@ void Dmp::train(const Trajectory& trajectory, string save_directory, bool overwr
       else
         save_directory_dim = save_directory + "/dim" + to_string(dd);
     }
-    
+
     // Actual training is happening here.
     VectorXd fa_target = f_target.col(dd);
     if (function_approximators_[dd]==NULL)
@@ -610,12 +610,12 @@ void Dmp::getSelectableParameters(set<string>& selectable_values_labels) const {
     }
   }
   selectable_values_labels.insert("goal");
-  
-  //cout << "selected_values_labels=["; 
-  //for (string label : selected_values_labels) 
+
+  //cout << "selected_values_labels=[";
+  //for (string label : selected_values_labels)
   //  cout << label << " ";
   //cout << "]" << endl;
-  
+
 }
 
 void Dmp::setSelectedParameters(const set<string>& selected_values_labels)
@@ -635,13 +635,13 @@ void Dmp::setSelectedParameters(const set<string>& selected_values_labels)
     if (function_approximators_[dd]!=NULL)
       if (function_approximators_[dd]->isTrained())
         lengths_per_dimension[dd] = function_approximators_[dd]->getParameterVectorSelectedSize();
-    
+
     if (selected_values_labels.find("goal")!=selected_values_labels.end())
       lengths_per_dimension[dd]++;
   }
-  
+
   setVectorLengthsPerDimension(lengths_per_dimension);
-      
+
 }
 
 void Dmp::getParameterVectorMask(const std::set<std::string> selected_values_labels, Eigen::VectorXi& selected_mask) const
@@ -655,7 +655,7 @@ void Dmp::getParameterVectorMask(const std::set<std::string> selected_values_lab
 
   selected_mask.resize(getParameterVectorAllSize());
   selected_mask.fill(0);
-  
+
   const int TMP_GOAL_NUMBER = -1;
   int offset = 0;
   VectorXi cur_mask;
@@ -663,29 +663,29 @@ void Dmp::getParameterVectorMask(const std::set<std::string> selected_values_lab
   {
     function_approximators_[dd]->getParameterVectorMask(selected_values_labels,cur_mask);
 
-    // This makes sure that the indices for each function approximator are different    
-    int mask_offset = selected_mask.maxCoeff(); 
+    // This makes sure that the indices for each function approximator are different
+    int mask_offset = selected_mask.maxCoeff();
     for (int ii=0; ii<cur_mask.size(); ii++)
       if (cur_mask[ii]!=0)
         cur_mask[ii] += mask_offset;
-        
+
     selected_mask.segment(offset,cur_mask.size()) = cur_mask;
     offset += cur_mask.size();
-    
+
     // Goal
     if (selected_values_labels.find("goal")!=selected_values_labels.end())
       selected_mask(offset) = TMP_GOAL_NUMBER;
     offset++;
-    
+
   }
   assert(offset == getParameterVectorAllSize());
-  
+
   // Replace TMP_GOAL_NUMBER with current max value
-  int goal_number = selected_mask.maxCoeff() + 1; 
+  int goal_number = selected_mask.maxCoeff() + 1;
   for (int ii=0; ii<selected_mask.size(); ii++)
     if (selected_mask[ii]==TMP_GOAL_NUMBER)
       selected_mask[ii] = goal_number;
-    
+
 }
 
 int Dmp::getParameterVectorAllSize(void) const
@@ -693,7 +693,7 @@ int Dmp::getParameterVectorAllSize(void) const
   int total_size = 0;
   for (unsigned int dd=0; dd<function_approximators_.size(); dd++)
     total_size += function_approximators_[dd]->getParameterVectorAllSize();
-  
+
   // For the goal
   total_size += dim_orig();
   return total_size;
@@ -729,13 +729,13 @@ void Dmp::setParameterVectorAll(const VectorXd& values)
     cur_values = values.segment(offset,n_parameters_required);
     function_approximators_[dd]->setParameterVectorAll(cur_values);
     offset += n_parameters_required;
-    
+
     attractor(dd) = values(offset);
     offset += 1;
   }
-  
+
   // Set the goal
-  set_attractor_state(attractor); 
+  set_attractor_state(attractor);
 }
 
 
@@ -743,7 +743,7 @@ void Dmp::setParameterVectorAll(const VectorXd& values)
 void Dmp::set_tau(double tau) {
   DynamicalSystem::set_tau(tau);
 
-  // Set value in all relevant subsystems also  
+  // Set value in all relevant subsystems also
   spring_system_->set_tau(tau);
   if (goal_system_!=NULL)
     goal_system_->set_tau(tau);
@@ -753,25 +753,25 @@ void Dmp::set_tau(double tau) {
 
 void Dmp::set_initial_state(const VectorXd& y_init) {
   DynamicalSystem::set_initial_state(y_init);
-  
-  // Set value in all relevant subsystems also  
+
+  // Set value in all relevant subsystems also
   spring_system_->set_initial_state(y_init);
   if (goal_system_!=NULL)
     goal_system_->set_initial_state(y_init);
-}    
+}
 
 void Dmp::set_attractor_state(const VectorXd& y_attr) {
   DynamicalSystem::set_attractor_state(y_attr);
-  
-  // Set value in all relevant subsystems also  
+
+  // Set value in all relevant subsystems also
   if (goal_system_!=NULL)
     goal_system_->set_attractor_state(y_attr);
 
-  // Do NOT do the following. The attractor state of the spring system is determined by the goal 
+  // Do NOT do the following. The attractor state of the spring system is determined by the goal
   // system
   // spring_system_->set_attractor_state(y_attr);
 
-}    
+}
 
 
 string Dmp::toString(void) const
@@ -786,7 +786,7 @@ void Dmp::serialize(Archive & ar, const unsigned int version)
   // serialize base class information
   ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(DynamicalSystem);
   ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Parameterizable);
-  
+
   ar & BOOST_SERIALIZATION_NVP(goal_system_);
   ar & BOOST_SERIALIZATION_NVP(spring_system_);
   ar & BOOST_SERIALIZATION_NVP(phase_system_);

--- a/src/dmp/Dmp.cpp
+++ b/src/dmp/Dmp.cpp
@@ -234,6 +234,7 @@ Dmp* Dmp::clone(void) const {
 
 void Dmp::integrateStart(Ref<VectorXd> x, Ref<VectorXd> xd) const
 {
+
   assert(x.size()==dim());
   assert(xd.size()==dim());
 
@@ -256,11 +257,11 @@ void Dmp::integrateStart(Ref<VectorXd> x, Ref<VectorXd> xd) const
 
   // Set the attractor state of the spring system
   spring_system_->set_attractor_state(x.GOAL);
-
   // Start integrating all futher subsystems
   spring_system_->integrateStart(x.SPRING, xd.SPRING);
   phase_system_->integrateStart(  x.PHASE,  xd.PHASE);
   gating_system_->integrateStart(x.GATING, xd.GATING);
+
 
   // Add rates of change
   differentialEquation(x,xd);
@@ -331,7 +332,6 @@ void Dmp::differentialEquation(const VectorXd& x, Ref<VectorXd> xd) const
   // Non-linear forcing term
   phase_system_->differentialEquation(x.PHASE, xd.PHASE);
   gating_system_->differentialEquation(x.GATING, xd.GATING);
-
   MatrixXd phase_state(1,1);
   phase_state = x.PHASE;
   MatrixXd fa_output(1,dim_orig());
@@ -341,7 +341,6 @@ void Dmp::differentialEquation(const VectorXd& x, Ref<VectorXd> xd) const
   double gating = (x.GATING)[0];
   VectorXd g_minus_y0 = (attractor_state()-initial_state()).transpose();
   VectorXd forcing_term = gating*fa_output.row(t0); // todo .array()*g_minus_y0.array();
-
   // Add forcing term to the ZD component of the spring state
   xd.SPRING_Z = xd.SPRING_Z + forcing_term/tau();
 

--- a/src/dmp/Dmp.cpp
+++ b/src/dmp/Dmp.cpp
@@ -20,7 +20,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
  */
-
+#define EIGEN2_SUPPORT
 #include <boost/serialization/export.hpp>
 #include <boost/serialization/vector.hpp>
 #include <boost/archive/text_iarchive.hpp>

--- a/src/dmp/Dmp.cpp~
+++ b/src/dmp/Dmp.cpp~
@@ -1,0 +1,797 @@
+/**
+ * @file Dmp.cpp
+ * @brief  Dmp class source file.
+ * @author Freek Stulp
+ *
+ * This file is part of DmpBbo, a set of libraries and programs for the 
+ * black-box optimization of dynamical movement primitives.
+ * Copyright (C) 2014 Freek Stulp, ENSTA-ParisTech
+ * 
+ * DmpBbo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ * 
+ * DmpBbo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <boost/serialization/export.hpp>
+#include <boost/serialization/vector.hpp>
+#include <boost/archive/text_iarchive.hpp>
+#include <boost/archive/text_oarchive.hpp>
+#include <boost/archive/xml_iarchive.hpp>
+#include <boost/archive/xml_oarchive.hpp>
+#include "dmp/Dmp.hpp"
+
+BOOST_CLASS_EXPORT_IMPLEMENT(DmpBbo::Dmp);
+
+#include <cmath>
+#include <iostream>
+#include <fstream>
+#include <string>
+#include <eigen3/Eigen/Core>
+
+#include "dmp/Trajectory.hpp"
+#include "functionapproximators/FunctionApproximator.hpp"
+#include "dynamicalsystems/SpringDamperSystem.hpp"
+#include "dynamicalsystems/ExponentialSystem.hpp"
+#include "dynamicalsystems/TimeSystem.hpp"
+#include "dynamicalsystems/SigmoidSystem.hpp"
+
+#include "dmpbbo_io/EigenBoostSerialization.hpp"
+#include "dmpbbo_io/BoostSerializationToString.hpp"
+
+
+using namespace std;
+using namespace Eigen;
+
+namespace DmpBbo {
+
+#define SPRING    segment(0*dim_orig()+0,2*dim_orig())
+#define SPRING_Y  segment(0*dim_orig()+0,dim_orig())
+#define SPRING_Z  segment(1*dim_orig()+0,dim_orig())
+#define GOAL      segment(2*dim_orig()+0,dim_orig())
+#define PHASE     segment(3*dim_orig()+0,       1)
+#define GATING    segment(3*dim_orig()+1,       1)
+
+#define SPRINGM(T)    block(0,0*dim_orig()+0,T,2*dim_orig())
+#define SPRINGM_Y(T)  block(0,0*dim_orig()+0,T,dim_orig())
+#define SPRINGM_Z(T)  block(0,1*dim_orig()+0,T,dim_orig())
+#define GOALM(T)      block(0,2*dim_orig()+0,T,dim_orig())
+#define PHASEM(T)     block(0,3*dim_orig()+0,T,       1)
+#define GATINGM(T)    block(0,3*dim_orig()+1,T,       1)
+
+boost::mt19937 Dmp::rng = boost::mt19937(getpid() + time(0));
+
+Dmp::Dmp(double tau, VectorXd y_init, VectorXd y_attr, 
+         vector<FunctionApproximator*> function_approximators,
+         double alpha_spring_damper, 
+         DynamicalSystem* goal_system,
+         DynamicalSystem* phase_system, 
+         DynamicalSystem* gating_system)
+  : DynamicalSystem(1, tau, y_init, y_attr, "name"),
+  goal_system_(goal_system),
+  phase_system_(phase_system), gating_system_(gating_system) 
+{
+  initSubSystems(alpha_spring_damper, goal_system, phase_system, gating_system);
+  initFunctionApproximators(function_approximators);
+}
+
+  
+Dmp::Dmp(int n_dims_dmp, vector<FunctionApproximator*> function_approximators, 
+   double alpha_spring_damper, DynamicalSystem* goal_system,
+   DynamicalSystem* phase_system, DynamicalSystem* gating_system)
+  : DynamicalSystem(1, 1.0, VectorXd::Zero(n_dims_dmp), VectorXd::Ones(n_dims_dmp), "name"),
+  goal_system_(goal_system),
+  phase_system_(phase_system), gating_system_(gating_system), function_approximators_(function_approximators)
+{
+  initSubSystems(alpha_spring_damper, goal_system, phase_system, gating_system);
+  initFunctionApproximators(function_approximators);
+}
+    
+Dmp::Dmp(double tau, VectorXd y_init, VectorXd y_attr, 
+         vector<FunctionApproximator*> function_approximators, 
+         DmpType dmp_type)
+  : DynamicalSystem(1, tau, y_init, y_attr, "name")
+{  
+  initSubSystems(dmp_type);
+  initFunctionApproximators(function_approximators);
+}
+  
+Dmp::Dmp(int n_dims_dmp, 
+         vector<FunctionApproximator*> function_approximators, 
+         DmpType dmp_type)
+  : DynamicalSystem(1, 1.0, VectorXd::Zero(n_dims_dmp), VectorXd::Ones(n_dims_dmp), "name")
+{
+  initSubSystems(dmp_type);
+  initFunctionApproximators(function_approximators);
+}
+
+Dmp::Dmp(double tau, VectorXd y_init, VectorXd y_attr, double alpha_spring_damper, DynamicalSystem* goal_system) 
+  : DynamicalSystem(1, tau, y_init, y_attr, "name")
+{
+  
+  VectorXd one_1 = VectorXd::Ones(1);
+  VectorXd one_0 = VectorXd::Zero(1);
+  DynamicalSystem* phase_system  = new ExponentialSystem(tau,one_1,one_0,4);
+  DynamicalSystem* gating_system = new ExponentialSystem(tau,one_1,one_0,4); 
+  initSubSystems(alpha_spring_damper, goal_system, phase_system, gating_system);
+
+  vector<FunctionApproximator*> function_approximators(y_init.size());    
+  for (int dd=0; dd<y_init.size(); dd++)
+    function_approximators[dd] = NULL;
+  initFunctionApproximators(function_approximators);  
+}
+
+void Dmp::initSubSystems(DmpType dmp_type)
+{
+  VectorXd one_1 = VectorXd::Ones(1);
+  VectorXd one_0 = VectorXd::Zero(1);
+  
+  DynamicalSystem *goal_system=NULL;
+  DynamicalSystem *phase_system=NULL;
+  DynamicalSystem *gating_system=NULL;
+  if (dmp_type==IJSPEERT_2002_MOVEMENT)
+  {
+    goal_system   = NULL;
+    phase_system  = new ExponentialSystem(tau(),one_1,one_0,4);
+    gating_system = new ExponentialSystem(tau(),one_1,one_0,4); 
+  }                                                          
+  else if (dmp_type==KULVICIUS_2012_JOINING || dmp_type==COUNTDOWN_2013)
+  {
+    goal_system   = new ExponentialSystem(tau(),initial_state(),attractor_state(),15);
+    gating_system = new SigmoidSystem(tau(),one_1,-40,0.9*tau()); 
+    bool count_down = (dmp_type==COUNTDOWN_2013);    
+    phase_system  = new TimeSystem(tau(),count_down);
+  }
+  
+  double alpha_spring_damper = 20;
+  
+  initSubSystems(alpha_spring_damper, goal_system, phase_system, gating_system);
+}
+
+void Dmp::initSubSystems(double alpha_spring_damper, DynamicalSystem* goal_system,
+  DynamicalSystem* phase_system, DynamicalSystem* gating_system)
+{
+
+  // Make room for the subsystems
+  set_dim(3*dim_orig()+2);
+    
+  spring_system_ = new SpringDamperSystem(tau(),initial_state(),attractor_state(),alpha_spring_damper);  
+  spring_system_->set_name(name()+"_spring-damper");
+  analytical_solution_perturber_ = NULL; // Do not perturb spring-damper as default
+
+  goal_system_ = goal_system;
+  if (goal_system!=NULL)
+  {
+    assert(goal_system->dim()==dim_orig());
+    // Initial state of the goal system is that same as that of the DMP
+    goal_system_->set_initial_state(initial_state());
+    goal_system_->set_name(name()+"_goal");
+  }
+
+  phase_system_ = phase_system;
+  phase_system_->set_name(name()+"_phase");
+
+  gating_system_ = gating_system;
+  gating_system_->set_name(name()+"_gating");
+
+}
+
+void Dmp::set_damping_coefficient(double damping_coefficient)
+{
+  spring_system_->set_damping_coefficient(damping_coefficient); 
+}
+void Dmp::set_spring_constant(double spring_constant) {
+  spring_system_->set_spring_constant(spring_constant); 
+}
+  
+
+void Dmp::initFunctionApproximators(vector<FunctionApproximator*> function_approximators)
+{
+  if (function_approximators.empty())
+    return;
+  
+  assert(dim_orig()==(int)function_approximators.size());
+  
+  function_approximators_ = vector<FunctionApproximator*>(function_approximators.size());
+  for (unsigned int dd=0; dd<function_approximators.size(); dd++)
+  {
+    if (function_approximators[dd]==NULL)
+      function_approximators_[dd] = NULL;
+    else
+      function_approximators_[dd] = function_approximators[dd]->clone();
+  }
+
+}
+
+Dmp::~Dmp(void)
+{
+  delete goal_system_;   
+  delete spring_system_;
+  delete phase_system_;
+  delete gating_system_;
+  for (unsigned int ff=0; ff<function_approximators_.size(); ff++)
+    delete (function_approximators_[ff]);
+}
+
+Dmp* Dmp::clone(void) const {
+  vector<FunctionApproximator*> function_approximators;
+  for (unsigned int ff=0; ff<function_approximators_.size(); ff++)
+    function_approximators.push_back(function_approximators_[ff]->clone());
+  
+  return new Dmp(tau(), initial_state(), attractor_state(), function_approximators,
+   spring_system_->damping_coefficient(), goal_system_->clone(),
+   phase_system_->clone(), gating_system_->clone());
+}
+
+
+void Dmp::integrateStart(Ref<VectorXd> x, Ref<VectorXd> xd) const
+{
+  assert(x.size()==dim());
+  assert(xd.size()==dim());
+  
+  x.fill(0);  
+  xd.fill(0);  
+  
+  // Start integrating goal system if it exists
+  if (goal_system_==NULL)
+  {
+    // No goal system, simply set goal state to attractor state
+    x.GOAL = attractor_state();
+    xd.GOAL.fill(0);
+  }
+  else
+  {
+    // Goal system exists. Start integrating it.
+    goal_system_->integrateStart(x.GOAL,xd.GOAL);
+  }
+  
+    
+  // Set the attractor state of the spring system
+  spring_system_->set_attractor_state(x.GOAL);
+  
+  // Start integrating all futher subsystems
+  spring_system_->integrateStart(x.SPRING, xd.SPRING);
+  phase_system_->integrateStart(  x.PHASE,  xd.PHASE);
+  gating_system_->integrateStart(x.GATING, xd.GATING);
+
+  // Add rates of change
+  differentialEquation(x,xd);
+  
+}
+
+/*
+bool Dmp::isTrained(void) const
+{
+  for (int i_dim=0; i_dim<dim_orig(); i_dim++)
+    if (function_approximators_[i_dim]!=NULL)
+      return false;
+    
+  for (int i_dim=0; i_dim<dim_orig(); i_dim++)
+    if (function_approximators_[i_dim]->isTrained()) 
+      return false;
+    
+  return true;
+}
+*/
+
+void Dmp::computeFunctionApproximatorOutput(const MatrixXd& phase_state, MatrixXd& fa_output) const
+{
+  int T = phase_state.rows();
+  fa_output.resize(T,dim_orig());
+  fa_output.fill(0.0);
+  
+  MatrixXd output(T,1);
+  for (int i_dim=0; i_dim<dim_orig(); i_dim++)
+  {
+    if (function_approximators_[i_dim]!=NULL)
+    {
+      if (function_approximators_[i_dim]->isTrained()) 
+      {
+        function_approximators_[i_dim]->predict(phase_state,output);
+        fa_output.col(i_dim) = output;
+      }
+    }
+  }
+}
+
+void Dmp::differentialEquation(const VectorXd& x, Ref<VectorXd> xd) const
+{
+  
+  if (goal_system_==NULL)
+  {
+    // If there is no dynamical system for the delayed goal, the goal is
+    // simply the attractor state
+    spring_system_->set_attractor_state(attractor_state());
+    // with zero change
+    xd.GOAL.fill(0);
+  } 
+  else
+  {
+    // Integrate goal system and get current goal state
+    goal_system_->set_attractor_state(attractor_state());
+    goal_system_->differentialEquation(x.GOAL, xd.GOAL);
+    // The goal state is the attractor state of the spring-damper system
+    spring_system_->set_attractor_state(x.GOAL);
+        
+  }
+
+  // Integrate spring damper system
+  // Forcing term is added to spring_state later
+  spring_system_->differentialEquation(x.SPRING, xd.SPRING);
+
+  
+  // Non-linear forcing term
+  phase_system_->differentialEquation(x.PHASE, xd.PHASE);
+  gating_system_->differentialEquation(x.GATING, xd.GATING);
+
+  MatrixXd phase_state(1,1);
+  phase_state = x.PHASE;
+  MatrixXd fa_output(1,dim_orig());
+  computeFunctionApproximatorOutput(phase_state, fa_output); 
+  
+  int t0 = 0;
+  double gating = (x.GATING)[0];
+  VectorXd g_minus_y0 = (attractor_state()-initial_state()).transpose();
+  VectorXd forcing_term = gating*fa_output.row(t0); // todo .array()*g_minus_y0.array();
+
+  // Add forcing term to the ZD component of the spring state
+  xd.SPRING_Z = xd.SPRING_Z + forcing_term/tau();
+
+
+}
+
+void Dmp::statesAsTrajectory(const MatrixXd& x_in, const MatrixXd& xd_in, MatrixXd& y_out, MatrixXd& yd_out, MatrixXd& ydd_out) const
+{
+  int n_time_steps = x_in.rows(); 
+  y_out  = x_in.SPRINGM_Y(n_time_steps);
+  yd_out = xd_in.SPRINGM_Y(n_time_steps);
+  ydd_out = xd_in.SPRINGM_Z(n_time_steps)/tau();
+  // MatrixXd z_out, zd_out;
+  // z_out  = x_in.SPRINGM_Z(n_time_steps);
+  // zd_out = xd_in.SPRINGM_Z(n_time_steps);
+  // Divide by tau to go from z to y space
+  // yd = z_out/obj.tau;
+  // ydd_out = zd_out/tau();
+}
+
+
+void Dmp::statesAsTrajectory(const VectorXd& ts, const MatrixXd& x_in, const MatrixXd& xd_in, Trajectory& trajectory) const {
+  int n_time_steps = ts.rows();
+#ifndef NDEBUG // Variables below are only required for asserts; check for NDEBUG to avoid warnings.
+  int n_dims       = x_in.cols();
+#endif
+  assert(n_time_steps==x_in.rows());
+  assert(n_time_steps==xd_in.rows());
+  assert(n_dims==xd_in.cols());
+
+  // Left column is time
+  Trajectory new_trajectory(
+    ts,
+    // y_out (see function above)
+    x_in.SPRINGM_Y(n_time_steps),
+    // yd_out (see function above)
+    xd_in.SPRINGM_Y(n_time_steps),
+    // ydd_out (see function above)
+    xd_in.SPRINGM_Z(n_time_steps)/tau()
+  );
+  
+  trajectory = new_trajectory;
+  
+}
+
+void Dmp::analyticalSolution(const VectorXd& ts, MatrixXd& xs, MatrixXd& xds, Eigen::MatrixXd& forcing_terms, Eigen::MatrixXd& fa_outputs) const
+{
+  int n_time_steps = ts.size();
+  assert(n_time_steps>0);
+  
+  // Usually, we expect xs and xds to be of size T X dim(), so we resize to that. However, if the
+  // input matrices were of size dim() X T, we return the matrices of that size by doing a 
+  // transposeInPlace at the end. That way, the user can also request dim() X T sized matrices.
+  bool caller_expects_transposed = (xs.rows()==dim() && xs.cols()==n_time_steps);
+  
+  // INTEGRATE SYSTEMS ANALYTICALLY AS MUCH AS POSSIBLE
+
+  // Integrate phase
+  MatrixXd xs_phase;
+  MatrixXd xds_phase;
+  phase_system_->analyticalSolution(ts,xs_phase,xds_phase);
+  
+  // Compute gating term
+  MatrixXd xs_gating;
+  MatrixXd xds_gating;
+  gating_system_->analyticalSolution(ts,xs_gating,xds_gating);
+
+  // Compute the output of the function approximator
+  fa_outputs.resize(ts.size(),dim_orig());
+  fa_outputs.fill(0.0);
+  //if (isTrained())
+  computeFunctionApproximatorOutput(xs_phase, fa_outputs);
+
+  MatrixXd xs_gating_rep = xs_gating.replicate(1,fa_outputs.cols());
+  MatrixXd g_minus_y0_rep = (attractor_state()-initial_state()).transpose().replicate(n_time_steps,1);
+  forcing_terms = fa_outputs.array()*xs_gating_rep.array(); // todo *g_minus_y0_rep.array();
+  
+  MatrixXd xs_goal, xds_goal;
+  // Get current delayed goal
+  if (goal_system_==NULL)
+  {
+    // If there is no dynamical system for the delayed goal, the goal is
+    // simply the attractor state               
+    xs_goal  = attractor_state().transpose().replicate(n_time_steps,1);
+    // with zero change
+    xds_goal = MatrixXd::Zero(n_time_steps,dim_orig());
+  } 
+  else
+  {
+    // Integrate goal system and get current goal state
+    goal_system_->analyticalSolution(ts,xs_goal,xds_goal);
+  }
+
+  xs.resize(n_time_steps,dim());
+  xds.resize(n_time_steps,dim());
+
+  int T = n_time_steps;
+    
+  xs.GOALM(T) = xs_goal;     xds.GOALM(T) = xds_goal;
+  xs.PHASEM(T) = xs_phase;   xds.PHASEM(T) = xds_phase;
+  xs.GATINGM(T) = xs_gating; xds.GATINGM(T) = xds_gating;
+
+  
+  // THE REST CANNOT BE DONE ANALYTICALLY
+  
+  // Reset the dynamical system, and get the first state
+  double damping = spring_system_->damping_coefficient();
+  SpringDamperSystem localspring_system_(tau(),initial_state(),attractor_state(),damping);
+  
+  // Set first attractor state
+  localspring_system_.set_attractor_state(xs_goal.row(0));
+  
+  // Start integrating spring damper system
+  int dim_spring = localspring_system_.dim();
+  VectorXd x_spring(dim_spring), xd_spring(dim_spring); // todo Why are these needed?
+  int t0 = 0;
+  localspring_system_.integrateStart(x_spring, xd_spring);
+  xs.row(t0).SPRING  = x_spring;
+  xds.row(t0).SPRING = xd_spring;
+
+  // Add forcing term to the acceleration of the spring state  
+  xds.SPRINGM_Z(1) = xds.SPRINGM_Z(1) + forcing_terms.row(t0)/tau();
+  
+  for (int tt=1; tt<n_time_steps; tt++)
+  {
+    double dt = ts[tt]-ts[tt-1];
+    
+    // Euler integration
+    xs.row(tt).SPRING  = xs.row(tt-1).SPRING + dt*xds.row(tt-1).SPRING;
+  
+    // Set the attractor state of the spring system
+    localspring_system_.set_attractor_state(xs.row(tt).GOAL);
+
+    // Integrate spring damper system
+    localspring_system_.differentialEquation(xs.row(tt).SPRING, xd_spring);
+    xds.row(tt).SPRING = xd_spring;
+    
+    RowVectorXd perturbation = RowVectorXd::Constant(dim_orig(),0.0);
+    if (analytical_solution_perturber_!=NULL)
+      for (int i_dim=0; i_dim<dim_orig(); i_dim++)
+        perturbation(i_dim) = (*analytical_solution_perturber_)();
+      
+    // Add forcing term to the acceleration of the spring state
+    xds.row(tt).SPRING_Z = xds.row(tt).SPRING_Z + forcing_terms.row(tt)/tau() + perturbation;
+    // Compute y component from z
+    xds.row(tt).SPRING_Y = xs.row(tt).SPRING_Z/tau();
+    
+  } 
+  
+  if (caller_expects_transposed)
+  {
+    xs.transposeInPlace();
+    xds.transposeInPlace();
+  }
+}
+
+void Dmp::computeFunctionApproximatorInputsAndTargets(const Trajectory& trajectory, VectorXd& fa_inputs_phase, MatrixXd& f_target) const
+{
+  int n_time_steps = trajectory.length();
+  double dim_data = trajectory.dim();
+  
+  if (dim_orig()!=dim_data)
+  {
+    cout << "WARNING: Cannot train " << dim_orig() << "-D DMP with " << dim_data << "-D data. Doing nothing." << endl;
+    return;
+  }
+  
+  // Integrate analytically to get goal, gating and phase states
+  MatrixXd xs_ana;
+  MatrixXd xds_ana;
+  
+  // Before, we would make clone of the dmp, and integrate it with the tau, and initial/attractor
+  // state of the trajectory. However, Thibaut needed to call this from outside the Dmp as well,
+  // with the tau/states of the this object. Therefore, we no longer clone. 
+  // Dmp* dmp_clone = static_cast<Dmp*>(this->clone());
+  // dmp_clone->set_tau(trajectory.duration());
+  // dmp_clone->set_initial_state(trajectory.initial_y());
+  // dmp_clone->set_attractor_state(trajectory.final_y());
+  // dmp_clone->analyticalSolution(trajectory.ts(),xs_ana,xds_ana);
+  analyticalSolution(trajectory.ts(),xs_ana,xds_ana);
+  MatrixXd xs_goal   = xs_ana.GOALM(n_time_steps);
+  MatrixXd xs_gating = xs_ana.GATINGM(n_time_steps);
+  MatrixXd xs_phase  = xs_ana.PHASEM(n_time_steps);
+  
+  fa_inputs_phase = xs_phase;
+  
+  // Get parameters from the spring-dampers system to compute inverse
+  double damping_coefficient = spring_system_->damping_coefficient();
+  double spring_constant     = spring_system_->spring_constant();
+  double mass                = spring_system_->mass();
+  if (mass!=1.0)
+  {
+    cout << "WARNING: Usually, spring-damper system of the DMP should have mass==1, but it is " << mass << endl;
+  }
+
+  // Compute inverse
+  f_target = tau()*tau()*trajectory.ydds() + (spring_constant*(trajectory.ys()-xs_goal) + damping_coefficient*tau()*trajectory.yds())/mass;
+  
+  //Factor out gating term
+  for (unsigned int dd=0; dd<function_approximators_.size(); dd++)
+    f_target.col(dd) = f_target.col(dd).array()/xs_gating.array();
+ 
+}
+
+void Dmp::train(const Trajectory& trajectory)
+{
+  train(trajectory,"");
+}
+
+void Dmp::train(const Trajectory& trajectory, string save_directory, bool overwrite)
+{
+  
+  // Set tau, initial_state and attractor_state from the trajectory 
+  set_tau(trajectory.duration());
+  set_initial_state(trajectory.initial_y());
+  set_attractor_state(trajectory.final_y());
+  
+  VectorXd fa_input_phase;
+  MatrixXd f_target;
+  computeFunctionApproximatorInputsAndTargets(trajectory, fa_input_phase, f_target);
+  
+  // Some checks before training function approximators
+  assert(!function_approximators_.empty());
+  
+  for (unsigned int dd=0; dd<function_approximators_.size(); dd++)
+  {
+    // This is just boring stuff to figure out if and where to store the results of training
+    string save_directory_dim;
+    if (!save_directory.empty())
+    {
+      if (function_approximators_.size()==1)
+        save_directory_dim = save_directory;
+      else
+        save_directory_dim = save_directory + "/dim" + to_string(dd);
+    }
+    
+    // Actual training is happening here.
+    VectorXd fa_target = f_target.col(dd);
+    if (function_approximators_[dd]==NULL)
+    {
+      cerr << __FILE__ << ":" << __LINE__ << ":";
+      cerr << "WARNING: function approximator cannot be trained because it is NULL." << endl;
+    }
+    else
+    {
+      if (function_approximators_[dd]->isTrained())
+        function_approximators_[dd]->reTrain(fa_input_phase,fa_target,save_directory_dim,overwrite);
+      else
+        function_approximators_[dd]->train(fa_input_phase,fa_target,save_directory_dim,overwrite);
+    }
+  }
+}
+
+void Dmp::getSelectableParameters(set<string>& selectable_values_labels) const {
+  assert(function_approximators_.size()>0);
+  for (int dd=0; dd<dim_orig(); dd++)
+  {
+    if (function_approximators_[dd]!=NULL)
+    {
+      if (function_approximators_[dd]->isTrained())
+      {
+        set<string> cur_labels;
+        function_approximators_[dd]->getSelectableParameters(cur_labels);
+        selectable_values_labels.insert(cur_labels.begin(), cur_labels.end());
+      }
+    }
+  }
+  selectable_values_labels.insert("goal");
+  
+  //cout << "selected_values_labels=["; 
+  //for (string label : selected_values_labels) 
+  //  cout << label << " ";
+  //cout << "]" << endl;
+  
+}
+
+void Dmp::setSelectedParameters(const set<string>& selected_values_labels)
+{
+  assert(function_approximators_.size()>0);
+  for (int dd=0; dd<dim_orig(); dd++)
+    if (function_approximators_[dd]!=NULL)
+      if (function_approximators_[dd]->isTrained())
+        function_approximators_[dd]->setSelectedParameters(selected_values_labels);
+
+  // Call superclass for initializations
+  Parameterizable::setSelectedParameters(selected_values_labels);
+
+  VectorXi lengths_per_dimension = VectorXi::Zero(dim_orig());
+  for (int dd=0; dd<dim_orig(); dd++)
+  {
+    if (function_approximators_[dd]!=NULL)
+      if (function_approximators_[dd]->isTrained())
+        lengths_per_dimension[dd] = function_approximators_[dd]->getParameterVectorSelectedSize();
+    
+    if (selected_values_labels.find("goal")!=selected_values_labels.end())
+      lengths_per_dimension[dd]++;
+  }
+  
+  setVectorLengthsPerDimension(lengths_per_dimension);
+      
+}
+
+void Dmp::getParameterVectorMask(const std::set<std::string> selected_values_labels, Eigen::VectorXi& selected_mask) const
+{
+  assert(function_approximators_.size()>0);
+  for (int dd=0; dd<dim_orig(); dd++)
+  {
+    assert(function_approximators_[dd]!=NULL);
+    assert(function_approximators_[dd]->isTrained());
+  }
+
+  selected_mask.resize(getParameterVectorAllSize());
+  selected_mask.fill(0);
+  
+  const int TMP_GOAL_NUMBER = -1;
+  int offset = 0;
+  VectorXi cur_mask;
+  for (int dd=0; dd<dim_orig(); dd++)
+  {
+    function_approximators_[dd]->getParameterVectorMask(selected_values_labels,cur_mask);
+
+    // This makes sure that the indices for each function approximator are different    
+    int mask_offset = selected_mask.maxCoeff(); 
+    for (int ii=0; ii<cur_mask.size(); ii++)
+      if (cur_mask[ii]!=0)
+        cur_mask[ii] += mask_offset;
+        
+    selected_mask.segment(offset,cur_mask.size()) = cur_mask;
+    offset += cur_mask.size();
+    
+    // Goal
+    if (selected_values_labels.find("goal")!=selected_values_labels.end())
+      selected_mask(offset) = TMP_GOAL_NUMBER;
+    offset++;
+    
+  }
+  assert(offset == getParameterVectorAllSize());
+  
+  // Replace TMP_GOAL_NUMBER with current max value
+  int goal_number = selected_mask.maxCoeff() + 1; 
+  for (int ii=0; ii<selected_mask.size(); ii++)
+    if (selected_mask[ii]==TMP_GOAL_NUMBER)
+      selected_mask[ii] = goal_number;
+    
+}
+
+int Dmp::getParameterVectorAllSize(void) const
+{
+  int total_size = 0;
+  for (unsigned int dd=0; dd<function_approximators_.size(); dd++)
+    total_size += function_approximators_[dd]->getParameterVectorAllSize();
+  
+  // For the goal
+  total_size += dim_orig();
+  return total_size;
+}
+
+
+void Dmp::getParameterVectorAll(VectorXd& values) const
+{
+  values.resize(getParameterVectorAllSize());
+  int offset = 0;
+  VectorXd cur_values;
+  VectorXd attractor = attractor_state();
+  for (int dd=0; dd<dim_orig(); dd++)
+  {
+    function_approximators_[dd]->getParameterVectorAll(cur_values);
+    values.segment(offset,cur_values.size()) = cur_values;
+    offset += cur_values.size();
+
+    values(offset) = attractor(dd);
+    offset++;
+  }
+}
+
+void Dmp::setParameterVectorAll(const VectorXd& values)
+{
+  assert(values.size()==getParameterVectorAllSize());
+  int offset = 0;
+  VectorXd cur_values;
+  VectorXd attractor(dim_orig());
+  for (int dd=0; dd<dim_orig(); dd++)
+  {
+    int n_parameters_required = function_approximators_[dd]->getParameterVectorAllSize();
+    cur_values = values.segment(offset,n_parameters_required);
+    function_approximators_[dd]->setParameterVectorAll(cur_values);
+    offset += n_parameters_required;
+    
+    attractor(dd) = values(offset);
+    offset += 1;
+  }
+  
+  // Set the goal
+  set_attractor_state(attractor); 
+}
+
+
+
+void Dmp::set_tau(double tau) {
+  DynamicalSystem::set_tau(tau);
+
+  // Set value in all relevant subsystems also  
+  spring_system_->set_tau(tau);
+  if (goal_system_!=NULL)
+    goal_system_->set_tau(tau);
+  phase_system_ ->set_tau(tau);
+  gating_system_->set_tau(tau);
+}
+
+void Dmp::set_initial_state(const VectorXd& y_init) {
+  DynamicalSystem::set_initial_state(y_init);
+  
+  // Set value in all relevant subsystems also  
+  spring_system_->set_initial_state(y_init);
+  if (goal_system_!=NULL)
+    goal_system_->set_initial_state(y_init);
+}    
+
+void Dmp::set_attractor_state(const VectorXd& y_attr) {
+  DynamicalSystem::set_attractor_state(y_attr);
+  
+  // Set value in all relevant subsystems also  
+  if (goal_system_!=NULL)
+    goal_system_->set_attractor_state(y_attr);
+
+  // Do NOT do the following. The attractor state of the spring system is determined by the goal 
+  // system
+  // spring_system_->set_attractor_state(y_attr);
+
+}    
+
+
+string Dmp::toString(void) const
+{
+  RETURN_STRING_FROM_BOOST_SERIALIZATION_XML("Dmp");
+}
+
+
+template<class Archive>
+void Dmp::serialize(Archive & ar, const unsigned int version)
+{
+  // serialize base class information
+  ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(DynamicalSystem);
+  ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Parameterizable);
+  
+  ar & BOOST_SERIALIZATION_NVP(goal_system_);
+  ar & BOOST_SERIALIZATION_NVP(spring_system_);
+  ar & BOOST_SERIALIZATION_NVP(phase_system_);
+  ar & BOOST_SERIALIZATION_NVP(gating_system_);
+  ar & BOOST_SERIALIZATION_NVP(function_approximators_);
+}
+
+}

--- a/src/dmp/Dmp.hpp~
+++ b/src/dmp/Dmp.hpp~
@@ -1,0 +1,568 @@
+/**
+ * @file Dmp.hpp
+ * @brief  Dmp class header file.
+ * @author Freek Stulp
+ *
+ * This file is part of DmpBbo, a set of libraries and programs for the 
+ * black-box optimization of dynamical movement primitives.
+ * Copyright (C) 2014 Freek Stulp, ENSTA-ParisTech
+ * 
+ * DmpBbo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ * 
+ * DmpBbo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _DMP_H_
+#define _DMP_H_
+#define EIGEN2_SUPPORT
+#include "dynamicalsystems/DynamicalSystem.hpp"
+#include "functionapproximators/Parameterizable.hpp"
+
+#include "dmpbbo_io/EigenBoostSerialization.hpp"
+#include <boost/serialization/assume_abstract.hpp>
+
+#include <boost/random.hpp>
+#include <boost/random/variate_generator.hpp>
+#include <boost/random/normal_distribution.hpp>
+
+#include <set>
+
+namespace DmpBbo {
+  
+// forward declaration
+class FunctionApproximator;
+class SpringDamperSystem;
+class Trajectory;
+
+/** \defgroup Dmps Dynamic Movement Primitives
+ */
+
+/** 
+ * \brief Implementation of Dynamical Movement Primitives.
+ * \ingroup Dmps
+ */
+class Dmp : public DynamicalSystem, public Parameterizable
+{
+public:
+  
+  /** Different types of DMPs that can be initialized. */
+  enum DmpType { IJSPEERT_2002_MOVEMENT, KULVICIUS_2012_JOINING, COUNTDOWN_2013  };
+
+
+  
+  /**
+   *  Initialization constructor.
+   *  \param tau             Time constant
+   *  \param y_init          Initial state
+   *  \param y_attr          Attractor state
+   *  \param alpha_spring_damper \f$\alpha\f$ in the spring-damper system of the dmp
+   *  \param goal_system     Dynamical system to compute delayed goal
+   *  \param phase_system    Dynamical system to compute the phase
+   *  \param gating_system   Dynamical system to compute the gating term
+   *  \param function_approximators Function approximators for the forcing term
+   */
+   Dmp(double tau, Eigen::VectorXd y_init, Eigen::VectorXd y_attr, std::vector<FunctionApproximator*> function_approximators,
+   double alpha_spring_damper, DynamicalSystem* goal_system,
+   DynamicalSystem* phase_system, DynamicalSystem* gating_system);
+  
+  /**
+   *  Initialization constructor for Dmps of known dimensionality, but with unknown initial and
+   *  attractor states.
+   *  \param n_dims_dmp      Dimensionality of the DMP
+   *  \param alpha_spring_damper \f$\alpha\f$ in the spring-damper system of the dmp
+   *  \param goal_system     Dynamical system to compute delayed goal
+   *  \param phase_system    Dynamical system to compute the phase
+   *  \param gating_system   Dynamical system to compute the gating term
+   *  \param function_approximators Function approximators for the forcing term
+   */
+   Dmp(int n_dims_dmp, std::vector<FunctionApproximator*> function_approximators, 
+   double alpha_spring_damper, DynamicalSystem* goal_system,
+   DynamicalSystem* phase_system, DynamicalSystem* gating_system);
+    
+  /**
+   *  Constructor that initializes the DMP with default dynamical systems.
+   *  \param tau       Time constant
+   *  \param y_init    Initial state
+   *  \param y_attr    Attractor state
+   *  \param function_approximators Function approximators for the forcing term
+   *  \param dmp_type  The type of DMP, see Dmp::DmpType    
+   */
+  Dmp(double tau, Eigen::VectorXd y_init, Eigen::VectorXd y_attr, std::vector<FunctionApproximator*> function_approximators, DmpType dmp_type=KULVICIUS_2012_JOINING);
+  
+  /**
+   *  Initialization constructor for Dmps of known dimensionality, but with unknown initial and
+   *  attractor states. Initializes the DMP with default dynamical systems.
+   *  \param n_dims_dmp      Dimensionality of the DMP
+   *  \param function_approximators Function approximators for the forcing term
+   *  \param dmp_type  The type of DMP, see Dmp::DmpType    
+   */
+  Dmp(int n_dims_dmp, std::vector<FunctionApproximator*> function_approximators,
+    DmpType dmp_type=KULVICIUS_2012_JOINING);      
+   
+  /**
+   *  Initialization constructor for Dmps without a forcing term.
+   *  \param tau             Time constant
+   *  \param y_init          Initial state
+   *  \param y_attr          Attractor state
+   *  \param alpha_spring_damper \f$\alpha\f$ in the spring-damper system of the dmp
+   *  \param goal_system     Dynamical system to compute delayed goal
+   */
+  Dmp(double tau, Eigen::VectorXd y_init, Eigen::VectorXd y_attr, double alpha_spring_damper, DynamicalSystem* goal_system);
+  
+  /** Destructor. */
+  ~Dmp(void);
+  
+  /** Return a deep copy of this object 
+   * \return A deep copy of this object
+   */
+  Dmp* clone(void) const;
+
+  
+  virtual void integrateStart(Eigen::Ref<Eigen::VectorXd> x, Eigen::Ref<Eigen::VectorXd> xd) const;
+  
+  void differentialEquation(const Eigen::VectorXd& x, Eigen::Ref<Eigen::VectorXd> xd) const;
+  
+  /**
+   * Return analytical solution of the system at certain times (and return forcing terms)
+   *
+   * \param[in]  ts  A vector of times for which to compute the analytical solutions
+   * \param[out] xs  Sequence of state vectors. T x D or D x T matrix, where T is the number of times (the length of 'ts'), and D the size of the state (i.e. dim())
+   * \param[out] xds Sequence of state vectors (rates of change). T x D or D x T matrix, where T is the number of times (the length of 'ts'), and D the size of the state (i.e. dim())
+   * \param[out] forcing_terms The forcing terms for each dimension, for debugging purposes only.
+   * \param[out] fa_output The output of the function approximators, for debugging purposes only.
+   *
+   * \remarks The output xs and xds will be of size D x T \em only if the matrix x you pass as an argument of size D x T. In all other cases (i.e. including passing an empty matrix) the size of x will be T x D. This feature has been added so that you may pass matrices of either size. 
+   */
+  void analyticalSolution(const Eigen::VectorXd& ts, Eigen::MatrixXd& xs, Eigen::MatrixXd& xds, Eigen::MatrixXd& forcing_terms, Eigen::MatrixXd& fa_output) const;
+  
+  /**
+   * Return analytical solution of the system at certain times (and return forcing terms)
+   *
+   * \param[in]  ts  A vector of times for which to compute the analytical solutions
+   * \param[out] xs  Sequence of state vectors. T x D or D x T matrix, where T is the number of times (the length of 'ts'), and D the size of the state (i.e. dim())
+   * \param[out] xds Sequence of state vectors (rates of change). T x D or D x T matrix, where T is the number of times (the length of 'ts'), and D the size of the state (i.e. dim())
+   * \param[out] forcing_terms The forcing terms for each dimension, for debugging purposes only.
+   *
+   * \remarks The output xs and xds will be of size D x T \em only if the matrix x you pass as an argument of size D x T. In all other cases (i.e. including passing an empty matrix) the size of x will be T x D. This feature has been added so that you may pass matrices of either size. 
+   */
+  inline void analyticalSolution(const Eigen::VectorXd& ts, Eigen::MatrixXd& xs, Eigen::MatrixXd& xds, Eigen::MatrixXd& forcing_terms) const
+  {
+    Eigen::MatrixXd fa_output;
+    analyticalSolution(ts, xs, xds, forcing_terms, fa_output);
+  }
+
+  inline void analyticalSolution(const Eigen::VectorXd& ts, Eigen::MatrixXd& xs, Eigen::MatrixXd& xds) const
+  {
+    Eigen::MatrixXd forcing_terms, fa_output;
+    analyticalSolution(ts, xs, xds, forcing_terms, fa_output);
+  }
+
+  /**
+   * Return analytical solution of the system at certain times
+   *
+   * \param[in]  ts  A vector of times for which to compute the analytical solutions
+   * \param[out] trajectory The computed states as a trajectory.
+   */
+  void analyticalSolution(const Eigen::VectorXd& ts, Trajectory& trajectory) const
+  {
+    Eigen::MatrixXd xs,  xds;
+    analyticalSolution(ts, xs, xds);
+    statesAsTrajectory(ts, xs, xds, trajectory);
+  }
+
+  /**
+   * Return analytical solution of the system at certain times
+   *
+   * \param[in]  ts  A vector of times for which to compute the analytical solutions
+   * \param[out] trajectory The computed states as a trajectory.
+   * \param[out] forcing_terms The forcing terms
+   */
+  inline void analyticalSolution(const Eigen::VectorXd& ts, Trajectory& trajectory, Eigen::MatrixXd& forcing_terms) const
+  {
+    Eigen::MatrixXd xs,  xds;
+    analyticalSolution(ts, xs, xds, forcing_terms);
+    statesAsTrajectory(ts, xs, xds, trajectory);
+  }
+
+  
+  
+  
+  /** Get the output of a DMP dynamical system as a trajectory.
+   *  As a dynamical system, the state vector of a DMP contains the output of the goal, spring, 
+   *  phase and gating system. What we are most interested in is the output of the spring system.
+   *  This function extracts that information, and also computes the accelerations of the spring
+   *  system, which are only stored implicitely in xd_in because second order systems are converted
+   *  to first order systems with expanded state.
+   *
+   * \param[in] x_in  State vector over time (size n_time_steps X dim())
+   * \param[in] xd_in State vector over time (rates of change)
+   * \param[out] y_out  State vector over time (size n_time_steps X dim_orig())
+   * \param[out] yd_out  State vector over time (rates of change)
+   * \param[out] ydd_out  State vector over time (rates of change of rates of change)
+   *  
+   */
+  virtual void statesAsTrajectory(const Eigen::MatrixXd& x_in, const Eigen::MatrixXd& xd_in, Eigen::MatrixXd& y_out, Eigen::MatrixXd& yd_out, Eigen::MatrixXd& ydd_out) const;
+  
+  /** Get the output of a DMP dynamical system as a trajectory.
+   *  As a dynamical system, the state vector of a DMP contains the output of the goal, spring, 
+   *  phase and gating system. What we are most interested in is the output of the spring system.
+   *  This function extracts that information, and also computes the accelerations of the spring
+   *  system, which are only stored implicitely in xd_in because second order systems are converted
+   *  to first order systems with expanded state.
+   *
+   * \param[in] ts    A vector of times 
+   * \param[in] x_in  State vector over time
+   * \param[in] xd_in State vector over time (rates of change)
+   * \param[out] trajectory Trajectory representation of the DMP state vector output.
+   *  
+   */
+  virtual void statesAsTrajectory(const Eigen::VectorXd& ts, const Eigen::MatrixXd& x_in, const Eigen::MatrixXd& xd_in, Trajectory& trajectory) const;
+  
+  /**
+   * Train a DMP with a trajectory.
+   * \param[in] trajectory The trajectory with which to train the DMP.
+   */
+  void train(const Trajectory& trajectory);
+      
+  /**
+   * Train a DMP with a trajectory, and write results to file
+   * \param[in] trajectory The trajectory with which to train the DMP.
+   * \param[in] save_directory The directory to which to save the results.
+   * \param[in] overwrite Overwrite existing files in the directory above (default: false)
+   */
+  void train(const Trajectory& trajectory, std::string save_directory, bool overwrite=false);
+
+  /**
+   * Accessor function for the time constant.
+   * \param[in] tau Time constant
+   * We need to override DynamicalSystem::set_tau, because the DMP must also change the time
+   * constant of all of its subsystems.
+   */
+  virtual void set_tau(double tau);
+
+  /** Accessor function for the initial state of the system.
+   *  \param[in] y_init Initial state of the system.
+   * We need to override DynamicalSystem::set_initial_state, because the DMP must also change 
+   * the initial state  of the goal system as well.
+   */
+  virtual void set_initial_state(const Eigen::VectorXd& y_init);
+  
+  /** Accessor function for the attractor state of the system. 
+   *  \param[in] y_attr Attractor state of the system.
+   */
+  virtual void set_attractor_state(const Eigen::VectorXd& y_attr);
+  
+  
+  /** 
+   * Accessor function for damping coefficient of spring-damper system
+   * \param[in] damping_coefficient Damping coefficient
+   */
+  void set_damping_coefficient(double damping_coefficient);
+  
+  /** 
+   * Accessor function for spring constant of spring-damper system
+   * \param[in] spring_constant Spring constant
+   */
+  void set_spring_constant(double spring_constant);
+
+	std::string toString(void) const;
+    
+  //virtual bool isTrained(void) const;
+  
+  void getSelectableParameters(std::set<std::string>& selectable_values_labels) const;
+  void setSelectedParameters(const std::set<std::string>& selected_values_labels);
+
+  int getParameterVectorAllSize(void) const;
+  void getParameterVectorAll(Eigen::VectorXd& values) const;
+  void setParameterVectorAll(const Eigen::VectorXd& values);
+  void getParameterVectorMask(const std::set<std::string> selected_values_labels, Eigen::VectorXi& selected_mask) const;
+
+  /** Given a trajectory, compute the inputs and targets for the function approximators.
+   * For a standard Dmp (such as the one in this class) the inputs will be the phase over time, and
+   * the targets will be the forcing term (with the gating function factored out).
+   * \param[in] trajectory Trajectory, e.g. a demonstration.
+   * \param[out] fa_inputs_phase The inputs for the function approximators (phase signal)
+   * \param[out] fa_targets The targets for the function approximators (forcing term)
+   */
+  void computeFunctionApproximatorInputsAndTargets(const Trajectory& trajectory, Eigen::VectorXd& fa_inputs_phase, Eigen::MatrixXd& fa_targets) const;
+  
+  /** Compute the outputs of the function approximators.
+   * \param[in] phase_state The phase states for which the outputs are computed.
+   * \param[out] fa_output The outputs of the function approximators.
+   */
+  virtual void computeFunctionApproximatorOutput(const Eigen::MatrixXd& phase_state, Eigen::MatrixXd& fa_output) const;
+  
+  void set_perturbation_analytical_solution(double perturbation_standard_deviation)
+  {
+    if (perturbation_standard_deviation>0.0)
+    {
+      boost::normal_distribution<> normal(0, perturbation_standard_deviation);
+      analytical_solution_perturber_ = new boost::variate_generator<boost::mt19937&, boost::normal_distribution<> >(rng, normal);
+    }
+    else
+    {
+      analytical_solution_perturber_ = NULL;
+    }
+  }
+  
+protected:
+
+  /** Get a pointer to the function approximator for a certain dimension.
+   * \param[in] i_dim Dimension for which to get the function approximator
+   * \return Pointer to the function approximator.
+   */
+  inline FunctionApproximator* function_approximator(int i_dim) const
+  {
+    assert(i_dim<(int)function_approximators_.size());
+    return function_approximators_[i_dim];
+  }
+   
+  
+private:
+  /** @name Linear closed loop controller
+   *  @{
+   */ 
+  /** Delayed goal system. Also see \ref sec_delayed_goal */
+  DynamicalSystem* goal_system_;   
+  /** Spring-damper system. Also see \ref page_dmp */
+  SpringDamperSystem* spring_system_;
+  /** @} */ // end of group_linear
+  
+  /** @name Non-linear open loop controller
+   *  @{
+   */ 
+  /** System that determined the phase of the movement. */
+  DynamicalSystem* phase_system_;
+  /** System to gate the output of the function approximators. Starts at 1 and converges to 0. */
+  DynamicalSystem* gating_system_;
+  
+  /** The function approximators, one for each dimension, in the forcing term. */
+  std::vector<FunctionApproximator*> function_approximators_;
+  /** @} */ // end of group_nonlinear
+  
+  /**
+   *  Helper function for constructor.
+   *  \param spring_system   Spring-damper system                 cf. Dmp::spring_system_
+   *  \param goal_system     System to compute delayed goal,      cf. Dmp::damping_coefficient_
+   *  \param phase_system    System tod compute the phase,        cf. Dmp::phase_system_
+   *  \param gating_system   System to compute the gating term,   cf. Dmp::gating_system_
+   *  \param function_approximators Function approximators for the forcing term, cf. Dmp::function_approximators_
+   */
+  void initSubSystems(double alpha_spring_system, DynamicalSystem* goal_system,
+    DynamicalSystem* phase_system, DynamicalSystem* gating_system);
+  
+  void initSubSystems(DmpType dmp_type);
+  
+  void initFunctionApproximators(std::vector<FunctionApproximator*> function_approximators);
+  
+  /** Boost's random number generator. Shared by all object instances. */
+  static boost::mt19937 rng;
+  boost::variate_generator<boost::mt19937&, boost::normal_distribution<> > *analytical_solution_perturber_;
+  
+protected:
+   Dmp(void) {};
+
+private:
+  /** Give boost serialization access to private members. */  
+  friend class boost::serialization::access;
+  
+  /** Serialize class data members to boost archive. 
+   * \param[in] ar Boost archive
+   * \param[in] version Version of the class
+   * See http://www.boost.org/doc/libs/1_55_0/libs/serialization/doc/tutorial.html#simplecase
+   */
+  template<class Archive>
+  void serialize(Archive & ar, const unsigned int version);
+
+};
+
+}
+
+#include <boost/serialization/export.hpp>
+
+/** Don't add version information to archives. */
+BOOST_SERIALIZATION_ASSUME_ABSTRACT(DmpBbo::Dmp);
+ 
+/** Don't add version information to archives. */
+BOOST_CLASS_IMPLEMENTATION(DmpBbo::Dmp,boost::serialization::object_serializable);
+
+#endif // _DMP_H_
+
+
+/** \page page_dmp Dynamical Movement Primitives Module
+
+\section sec_dmp_introduction Introduction
+
+The core idea behind dynamical movement primitives (DMPs) is to represent movement primitives as a combination of dynamical systems (please read \ref page_dyn_sys, if you haven't already done so). The state variables of the main dynamical system \f$ [\mathbf{y \dot{y} \ddot{y}} ]\f$ then represent trajectories for controlling, for instance, the 7 joints of a robot arm, or its 3D end-effector position. The attractor state is the end-point or \em goal of the movement.
+
+The key advantage of DMPs is that they inherit the nice properties from linear dynamical systems (guaranteed convergence towards the attractor, robustness to perturbations, independence of time, etc) whilst allowing arbitrary (smooth) motions to be represented by adding a non-linear forcing term. This forcing term is often learned from demonstration, and subsequently improved through reinforcement learning.
+
+DMPs were introduced in \cite ijspeert02movement, but in this section we follow largely the notation and description in \cite ijspeert13dynamical, but at a slower pace.
+
+\em Historical \em remark. Recently, the term "dynamicAL movement primitives" is preferred over "dynamic movement primitives". The newer term makes the relation to dynamicAL systems more clear, and avoids confusion about whether the output of "dynamical movement primitives" is in kinematic or dynamic space (it is usually in kinematic space).
+
+\em Remark. This documentation and code focusses only on discrete movement primitives. For rythmic movement primitives, we refer to \cite ijspeert13dynamical.
+
+
+\section sec_core Basic Point-to-Point Movements: A Critically Damped Spring-Damper System
+
+At the heart of the DMP lies a spring-damper system, as described in \ref dyn_sys_spring_damper. In DMP papers, the notation of the spring-damper system is usually a bit different:
+\f{eqnarray*}{
+m\ddot{y}  =& -ky -c\dot{y} & \mbox{spring-damper system, ``traditional notation''} \\
+m\ddot{y}  =& c(-\frac{k}{c}y - \dot{y})\\
+\tau\ddot{y}  =& \alpha(-\beta y - \dot{y})      & \mbox{with } \alpha=c,~~\beta = \frac{k}{c},~~m=\tau\\
+\tau\ddot{y}  =& \alpha(-\beta (y-y^g) - \dot{y})& \mbox{with attractor } y^g\\
+\tau\ddot{y}  =& \alpha(\beta (y^g-y) - \dot{y})& \mbox{typical DMP notation for spring-damper system}\\
+\f}
+
+In the last two steps, we change the attractor state from 0 to \f$y^g\f$, where \f$y^g\f$ is the goal of the movement.
+
+To avoid overshooting or slow convergence towards \f$y^g\f$, we prefer to have a \em critically \em damped spring-damper system for the DMP. For such systems \f$c = 2\sqrt{mk}\f$ must hold, see \ref dyn_sys_critical_damping. In our notation this becomes \f$\alpha = 2\sqrt{\alpha\beta}\f$, which leads to \f$\beta = \alpha/4\f$. This determines the value of \f$\beta\f$ for a given value of \f$\alpha\f$ in DMPs. The influence of \f$\alpha\f$ is illustrated in the first figure in \ref sec_dyn_sys_intro.
+
+Rewriting the second order dynamical system as a first order system (see \ref dyn_sys_rewrite_second_first) with expanded state \f$ [y~z]\f$ yields:
+
+\f{eqnarray*}{
+\left[ \begin{array}{l} {\dot{z}} \\ {\dot{y}} \end{array} \right] = \left[ \begin{array}{l} (\alpha (\beta({y}^{g}-{y})-{z}))/\tau \\ {z}/\tau  \end{array} \right]  \mbox{~~~~with init. state~} \left[ \begin{array}{l} 0 \\ y_0  \end{array} \right] \mbox{~and attr. state~} \left[ \begin{array}{l} {0} \\ {y}^g \end{array} \right]
+\f}
+
+
+\section sec_forcing Arbitrary Smooth Movements: the Forcing Term
+
+The representation described in the previous section has some nice properties in terms of 
+\ref sec_dyn_sys_convergence
+, \ref sec_dyn_sys_perturbations
+, and \ref sec_dyn_sys_autonomy, but it can only represent very simple movements. To achieve more complex movements, we add a time-dependent forcing term to the spring-damper system. The spring-damper systems and forcing term are together known as a \em transformation \em system.
+
+\f{eqnarray*}{
+\left[ \begin{array}{l} {\dot{z}} \\ {\dot{y}} \end{array} \right] = \left[ \begin{array}{l} (\alpha (\beta({y}^{g}-{y})-{z}) + f(t))/\tau \\ {z}/\tau  \end{array} \right]   \mbox{~~~~with init. state~} \left[ \begin{array}{l} 0 \\ y_0  \end{array} \right] \mbox{~and attr. state~} \left[ \begin{array}{l} {?} \\ {y}^g \end{array} \right]
+\f}
+
+The forcing term is an open loop controller, i.e. it depends only on time. By modifying the acceleration profile of the movement with a forcing term, arbitrary smooth movements can be achieved. The function \f$ f(t)\f$ is usually a function approximator, such as locally weighted regression (LWR) or locally weighted projection regression (LWPR), see \ref page_func_approx. The graph below shows an example of a forcing term implemented with LWR with random weights for the basis functions.
+
+\image html dmp_forcing_terms-svg.png "A non-linear forcing term enable more complex trajectories to be generated (these DMPs use a goal system and an exponential gating term)."
+\image latex dmp_forcing_terms-svg.pdf "A non-linear forcing term enable more complex trajectories to be generated (these DMPs use a goal system and an exponential gating term)." height=4cm
+
+\subsection sec_forcing_convergence Ensuring Convergence to 0 of the Forcing Term: the Gating System
+
+Since we add a forcing term to the dynamical system, we can no longer guarantee that the system will converge towards \f$ x^g \f$; perhaps the forcing term continually pushes it away \f$ x^g \f$ (perhaps it doesn't, but the point is that we cannot \em guarantee that it \em always doesn't). That is why there is a question mark in the attractor state in the equation above.
+To guarantee that the movement will always converge towards the attractor \f$ x^g \f$, we need to ensure that the forcing term decreases to 0 towards the end of the movement. To do so, a gating term is added, which is 1 at the beginning of the movement, and 0 at the end. This gating term itself is determined by, of course, a dynamical system. In \cite ijspeert02movement, it was suggested to use an exponential system. We add this extra system to our dynamical system by expanding the state as follows:
+
+\f{eqnarray*}{
+\dot{x} = \left[ \begin{array}{l} {\dot{z}} \\ {\dot{y}} \\ {\dot{x}} \end{array} \right] = \left[ \begin{array}{l} (\alpha_y (\beta_y({y}^{g}-{y})-{z}) + x\cdot f(t))/\tau \\ {z}/\tau \\ -\alpha_x x/\tau  \end{array} \right] \mbox{~~~~with init. state~} \left[ \begin{array}{l} 0 \\ y_0 \\ 1 \end{array} \right] \mbox{~and attr. state~} \left[ \begin{array}{l} {0} \\ {y}^g \\ 0 \end{array} \right]
+\f}
+
+\subsection sec_forcing_autonomy Ensuring Autonomy of the Forcing Term: the Phase System
+
+By introducing the dependence of the forcing term \f$ f(t)\f$ on time \f$ t \f$ the overall system is no longer autonomous. To achieve independence of time, we therefore let \f$ f \f$ be a function of the state of an (autonomous) dynamical system rather than of \f$ t \f$. This system represents the \em phase of the movement. \cite ijspeert02movement suggested to use the same dynamical system for the gating and phase, and use the term \em canonical \em system to refer this joint gating/phase system. Thus the phase of the movement starts at 1, and converges to 0 towards the end of the movement, just like the gating system. The new formulation now is (the only difference is \f$ f(x)\f$ instead of \f$ f(t)\f$):
+
+\f{eqnarray*}{
+\left[ \begin{array}{l} {\dot{z}} \\ {\dot{y}} \\ {\dot{x}} \end{array} \right] = \left[ \begin{array}{l} (\alpha_y (\beta_y({y}^{g}-{y})-{z}) + x\cdot f(x))/\tau \\ {z}/\tau \\ -\alpha_x x/\tau  \end{array} \right] \mbox{~~~~with init. state~} \left[ \begin{array}{l} 0 \\ y_0 \\ 1 \end{array} \right] \mbox{~and attr. state~} \left[ \begin{array}{l} {0} \\ {y}^g \\ 0 \end{array} \right]
+\f}
+
+\todo Discuss goal-dependent scaling, i.e. \f$ f(t)s(x^g-x_0) \f$?
+
+
+\subsection sec_multidim_dmp Multi-dimensional Dynamic Movement Primitives
+
+Since DMPs usually have multi-dimensional states (e.g. one output \f$ {\mathbf{y}}_{d=1\dots D}\f$ for each of the \f$ D \f$ joints), it is more accurate to use bold fonts for the state variables (except the gating/phase system, because it is always 1D) so that they represent vectors:
+
+\f{eqnarray*}{
+\left[ \begin{array}{l} {\dot{\mathbf{z}}} \\ {\dot{\mathbf{y}}} \\ {\dot{x}} \end{array} \right] = \left[ \begin{array}{l} (\alpha_y (\beta_y({\mathbf{y}}^{g}-\mathbf{y})-\mathbf{z}) + x\cdot f(x))/\tau \\ \mathbf{z}/\tau \\ -\alpha_x x/\tau  \end{array} \right] \mbox{~~~~with init. state~} \left[ \begin{array}{l} \mathbf{0} \\ \mathbf{z}_0 \\ 1 \end{array} \right] \mbox{~and attr. state~} \left[ \begin{array}{l} \mathbf{0} \\ \mathbf{y}^g \\ 0 \end{array} \right]
+\f}
+
+So far, the graphs have shown 1-dimensional systems. To generate D-dimensional trajectories for, for instance, the 7 joints of an arm or the 3D position of its end-effector, we simply use D transformation systems. A key principle in DMPs is to use one and the same phase system for all of the transformation systems, to ensure that the output of the transformation systems are synchronized in time. The image below show the evolution of all the dynamical systems involved in integrating a multi-dimensional DMP.
+
+\image html dmpplot_ijspeert2002movement-svg.png "The various dynamical systems and forcing terms in multi-dimensional DMPs."
+\image latex dmpplot_ijspeert2002movement-svg.pdf "The various dynamical systems and forcing terms in multi-dimensional DMPs." height=8cm
+
+<em>
+
+\subsection Implementation
+
+Since a Dynamical Movement Primitive is a dynamical system, the Dmp class derives from the DynamicalSystem class. It overrides the virtual function DynamicalSystem::integrateStart(). Integrating the DMP numerically (Euler or 4th order Runge-Kutta) is done with the generic DynamicalSystem::integrateStep() function. It also implements the pure virtual function DynamicalSystem::analyticalSolution(). Because a DMP cannot be solved analytically (we cannot write it in closed form due to the arbitrary forcing term), calling Dmp::analyticalSolution() in fact performs a numerical Euler integration (although the linear subsystems (phase, gating, etc.) are analytically solved because this is faster computationally).
+
+</em>
+
+
+\section sec_dmp_alternative Alternative Systems for Gating, Phase and Goals 
+
+\subsection sec_dmp_sigmoid_gating Gating: Sigmoid System
+
+A disadvantage of using an exponential system as a gating term is that the gating decreases very quickly in the beginning. Thus, the output of the function approximator \f$ f(x) \f$ needs to be very high towards the end of the movement if it is to have any effect at all. This leads to scaling issues when training the function approximator.
+
+Therefore, sigmoid systems have more recently been proposed \cite kulvicius12joining as a gating system. This leads to the following DMP formulation (since the gating and phase system are no longer shared, we introduce a new state variable \f$ v \f$ for the gating term:
+
+\f{eqnarray*}{
+\left[ \begin{array}{l} {\dot{\mathbf{z}}} \\ {\dot{\mathbf{y}}} \\ {\dot{x}}  \\ {\dot{v}} \end{array} \right] = \left[ \begin{array}{l} (\alpha_y (\beta_y({\mathbf{y}}^{g}-\mathbf{y})-\mathbf{z}) + v\cdot f(x))/\tau \\ \mathbf{z}/\tau \\ -\alpha_x x/\tau \\ -\alpha_v v (1-v/v_{\mbox{\scriptsize max}}) \end{array} \right] \mbox{~~~~with init. state~} \left[ \begin{array}{l} \mathbf{0} \\ \mathbf{y}_0 \\ 1 \\ 1 \end{array} \right]
+\mbox{~and attr. state~} \left[ \begin{array}{l} \mathbf{0} \\ \mathbf{y}^g \\ 0 \\ 0 \end{array} \right]
+\f}
+
+where the term \f$ v_{\mbox{\scriptsize max}}\f$ is determined by \f$\tau \f$
+
+\subsection sec_dmp_phase Phase: Constant Velocity System
+
+In practice, using an exponential phase system may complicate imitation learning of the function approximator \f$ f \f$, because samples are not equidistantly spaced in time. Therefore, we introduce a dynamical system that mimics the properties of the phase system described in \cite kulvicius12joining, whilst allowing for a more natural integration in the DMP formulation, and thus our code base. This system starts at 0, and has a constant velocity of \f$1/\tau\f$, which means the system reaches 1 when \f$t=\tau\f$. When this point is reached, the velocity is set to 0. 
+
+\f{eqnarray*}{
+\dot{x} =& 1/\tau \mbox{~if~} x < 1   & \\
+         & 0 \mbox{~if~} x>1 \\
+\f}
+
+This, in all honesty, is a bit of a hack, because it leads to a non-smooth acceleration profile. However, its properties as an input to the function approximator are so advantageous that we have designed it in this way (the implementation of this system is in the TimeSystem class).
+
+
+\image html phase_systems-svg.png "Exponential and constant velocity dynamical systems as the 1D phase for a dynamical movement primitive."
+\image latex phase_systems-svg.pdf "Exponential and constant velocity dynamical systems as the 1D phase for a dynamical movement primitive." height=4cm
+
+With the constant velocity dynamical system the DMP formulation becomes:
+
+\f{eqnarray*}{
+\left[ \begin{array}{l} {\dot{\mathbf{z}}} \\ {\dot{\mathbf{y}}} \\ {\dot{x}}  \\ {\dot{v}} \end{array} \right] = \left[ \begin{array}{l} (\alpha_y (\beta_y({\mathbf{y}}^{g}-\mathbf{y})-\mathbf{z}) + v\cdot f(x))/\tau \\ \mathbf{z}/\tau \\ 1/\tau \\ -\alpha_v v (1-v/v_{\mbox{\scriptsize max}}) \end{array} \right] \mbox{~~~~with init. state~} \left[ \begin{array}{l} \mathbf{0} \\ \mathbf{y}_0 \\ 0 \\ 1 \end{array} \right]
+\mbox{~and attr. state~} \left[ \begin{array}{l} \mathbf{0} \\ \mathbf{y}^g \\ 1 \\ 0 \end{array} \right]
+\f}
+
+\subsection sec_delayed_goal Zero Initial Accelerations: the Delayed Goal System
+
+Since the spring-damper system leads to high initial accelerations (see the graph to the right below), which is usually not desirable for robots, it was suggested to move the attractor of the system from the initial state \f$ y_0 \f$ to the goal state \f$ y^g \f$  \em during the movement \cite kulvicius12joining. This delayed goal attractor \f$ y^{g_d} \f$ itself is represented as an exponential dynamical system that starts at \f$ y_0 \f$, and converges to \f$ y^g \f$ (in early versions of DMPs, there was no delayed goal system, and \f$ y^{g_d} \f$ was simply equal to \f$ y^g \f$ throughout the movement). The combination of these two systems, listed below, leads to a movement that starts and ends with 0 velocities and accelerations, and approximately has a bell-shaped velocity profile. This representation is thus well suited to generating human-like point-to-point movements, which have similar properties.
+
+\f{eqnarray*}{
+\left[ \begin{array}{l} {\dot{\mathbf{z}}} \\ {\dot{\mathbf{y}}} \\ {\dot{\mathbf{y}}^{g_d}} \\ {\dot{x}}  \\ {\dot{v}} \end{array} \right] = \left[ \begin{array}{l} (\alpha_y (\beta_y({\mathbf{y}}^{g_d}-\mathbf{y})-\mathbf{z}) + v\cdot f(x))/\tau \\ \mathbf{z}/\tau \\ -\alpha_g({\mathbf{y}^g-\mathbf{y}^{g_d}}) \\ 1/\tau \\ -\alpha_v v (1-v/v_{\mbox{\scriptsize max}}) \end{array} \right] \mbox{~~~~with init. state~} \left[ \begin{array}{l} \mathbf{0} \\ \mathbf{y}_0 \\ \mathbf{y}_0 \\ 0 \\ 1 \end{array} \right]
+\mbox{~and attr. state~} \left[ \begin{array}{l} \mathbf{0} \\ \mathbf{y}^g \\ \mathbf{y}^g \\ 1 \\ 0 \end{array} \right]
+\f}
+
+
+\image html dmp_and_goal_system-svg.png "A first dynamical movement primitive, with and without a delayed goal system (left: state variable, center: velocities, right: accelerations."
+\image latex dmp_and_goal_system-svg.pdf "A first dynamical movement primitive, with and without a delayed goal system (left: state variable, center: velocities, right: accelerations." height=4cm
+
+
+In my experience, this DMP formulation is the best for learning human-like point-to-point movements (bell-shaped velocity profile, approximately zero velocities and accelerations at beginning and start of the movement), and generates nice normalized data for the function approximator without scaling issues (an exact empirical evaluation is on the stack...). The image below shows the interactions between the spring-damper system, delayed goal system, phase system and gating system.
+
+
+\image html dmpplot_kulvicius2012joining-svg.png "The various dynamical systems and forcing terms in multi-dimensional DMPs."
+\image latex dmpplot_kulvicius2012joining-svg.pdf "The various dynamical systems and forcing terms in multi-dimensional DMPs." height=7cm
+
+
+\section sec_dmp_issues Known Issues
+
+\todo Known Issues
+
+\li Scaling towards novel goals
+
+\section sec_dmp_summary Summary
+
+The core idea in dynamical movement primitives is to combine dynamical systems, which have nice properties in terms of convergence towards the goal, robustness to perturbations, and independence of time, with function approximators, which allow for the generation of arbitrary (smooth) trajectories. The key enabler to this approach is to gate the output of the function approximator with a gating system, which is 1 at the beginning of the movement, and 0 towards the end.
+
+Further enhancements can be made by making the system autonomous (by using the output of a phase system rather than time as an input to the function approximator), or having initial velocities and accelerations of 0 (by using a delayed goal system).
+
+Multi-dimensional DMPs are achieved by using multi-dimensional dynamical systems, and learning one function approximator for each dimension. Synchronization of the different dimensions is ensure by coupling them with only \em one phase system.
+
+*/

--- a/src/dmp/DmpContextual.cpp
+++ b/src/dmp/DmpContextual.cpp
@@ -20,7 +20,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
  */
-
+#define EIGEN2_SUPPORT
 #include "dmp/DmpContextual.hpp"
 
 #include "dmp/Trajectory.hpp"

--- a/src/dmp/DmpContextual.cpp~
+++ b/src/dmp/DmpContextual.cpp~
@@ -1,0 +1,124 @@
+/**
+ * @file DmpContextual.cpp
+ * @brief  DmpContextual class source file.
+ * @author Freek Stulp
+ *
+ * This file is part of DmpBbo, a set of libraries and programs for the 
+ * black-box optimization of dynamical movement primitives.
+ * Copyright (C) 2014 Freek Stulp, ENSTA-ParisTech
+ * 
+ * DmpBbo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ * 
+ * DmpBbo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "dmp/DmpContextual.hpp"
+
+#include "dmp/Trajectory.hpp"
+
+#include <iostream>
+#include <eigen3/Eigen/Core>
+
+
+using namespace std;
+using namespace Eigen;
+
+namespace DmpBbo {
+
+DmpContextual::DmpContextual(int n_dims_dmp, vector<FunctionApproximator*> function_approximators, DmpType dmp_type) 
+:  Dmp(n_dims_dmp, function_approximators, dmp_type)
+{
+   
+}
+
+// In the end, all of the below train(...) variants call the pure virtual function
+// virtual void  train(const std::vector<Trajectory>& trajectories, const std::vector<Eigen::MatrixXd>& task_parameters, std::string save_directory, bool overwrite) = 0;
+
+
+void  DmpContextual::train(const vector<Trajectory>& trajectories, const vector<MatrixXd>& task_parameters, string save_directory)
+{
+  bool overwrite = false;
+  train(trajectories, task_parameters, save_directory, overwrite);
+}
+
+void  DmpContextual::train(const vector<Trajectory>& trajectories, const vector<MatrixXd>& task_parameters)
+{
+  bool overwrite=false;
+  string save_directory("");
+  train(trajectories, task_parameters, save_directory, overwrite);
+}
+
+void  DmpContextual::train(const vector<Trajectory>& trajectories, string save_directory, bool overwrite)
+{
+  vector<MatrixXd> task_parameters(trajectories.size());
+  for (unsigned int i_traj=0; i_traj<trajectories.size(); i_traj++)
+  {
+    task_parameters[i_traj] = trajectories[i_traj].misc();
+    assert(task_parameters[i_traj].cols()>0);
+    if (i_traj>0)
+      assert(task_parameters[i_traj].cols() ==  task_parameters[i_traj].cols());
+  }
+  train(trajectories, task_parameters, save_directory, overwrite);
+}
+
+void  DmpContextual::train(const vector<Trajectory>& trajectories, string save_directory)
+{
+  bool overwrite=false;
+  train(trajectories, save_directory, overwrite);
+}
+
+void  DmpContextual::train(const vector<Trajectory>& trajectories)
+{
+  bool overwrite=false;
+  string save_directory("");
+  train(trajectories, save_directory, overwrite);
+}
+
+
+void  DmpContextual::checkTrainTrajectories(const vector<Trajectory>& trajectories)
+{
+  // Check if inputs are of the right size.
+  unsigned int n_demonstrations = trajectories.size();
+  
+  // Then check if the trajectories have the same duration and initial/final state
+  double first_duration = trajectories[0].duration();
+  VectorXd first_y_init = trajectories[0].initial_y();
+  VectorXd first_y_attr = trajectories[0].final_y();  
+  for (unsigned int i_demo=1; i_demo<n_demonstrations; i_demo++)
+  {
+    // Difference in tau
+    if (fabs(first_duration-trajectories[i_demo].duration())>10e-4)
+    {
+      cerr << __FILE__ << ":" << __LINE__ << ":";
+      cerr << "WARNING: Duration of demonstrations differ (" << first_duration << "!=" << trajectories[i_demo].duration() << ")" << endl;
+    }
+    
+    // Difference between initial states
+    double sum_abs_diff = (first_y_init.array()-trajectories[i_demo].initial_y().array()).abs().sum();
+    if (sum_abs_diff>10e-7)
+    {
+      cerr << __FILE__ << ":" << __LINE__ << ":";
+      cerr << "WARNING: Final states of demonstrations differ ( [" << first_y_init.transpose() << "] != [ " << trajectories[i_demo].initial_y().transpose() << "] )" << endl;
+    }
+    
+    // Difference between final states
+    sum_abs_diff = (first_y_attr.array()-trajectories[i_demo].final_y().array()).abs().sum();
+    if (sum_abs_diff>10e-7)
+    {
+      cerr << __FILE__ << ":" << __LINE__ << ":";
+      cerr << "WARNING: Final states of demonstrations differ ( [" << first_y_attr.transpose() << "] != [ " << trajectories[i_demo].final_y().transpose() << "] )" << endl;
+    }
+    
+  }
+}
+
+}

--- a/src/dmp/DmpContextualOneStep.cpp
+++ b/src/dmp/DmpContextualOneStep.cpp
@@ -20,7 +20,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
  */
-
+#define EIGEN2_SUPPORT
 #include "dmp/DmpContextualOneStep.hpp"
 
 #include <iomanip>

--- a/src/dmp/DmpContextualOneStep.cpp~
+++ b/src/dmp/DmpContextualOneStep.cpp~
@@ -1,0 +1,170 @@
+/**
+ * @file DmpContextualOneStep.cpp
+ * @brief  Contextual Dmp class header file.
+ * @author Freek Stulp
+ *
+ * This file is part of DmpBbo, a set of libraries and programs for the 
+ * black-box optimization of dynamical movement primitives.
+ * Copyright (C) 2014 Freek Stulp, ENSTA-ParisTech
+ * 
+ * DmpBbo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ * 
+ * DmpBbo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "dmp/DmpContextualOneStep.hpp"
+
+#include <iomanip>
+#include <iostream>
+#include <eigen3/Eigen/Core>
+
+#include "dmp/Trajectory.hpp"
+#include "functionapproximators/FunctionApproximator.hpp"
+
+using namespace std;
+using namespace Eigen;
+
+namespace DmpBbo {
+
+DmpContextualOneStep::DmpContextualOneStep(int n_dims_dmp, vector<FunctionApproximator*> function_approximators,
+  DmpType dmp_type) 
+:  DmpContextual(n_dims_dmp, function_approximators, dmp_type)
+{
+}
+  
+// Overloads in DMP computeFunctionApproximatorOutput
+void DmpContextualOneStep::computeFunctionApproximatorOutput(const MatrixXd& phase_state, MatrixXd& fa_output) const
+{
+  int n_time_steps = phase_state.rows(); 
+  fa_output.resize(n_time_steps,dim_orig());
+  fa_output.fill(0.0);
+  
+  MatrixXd task_parameters = task_parameters_;
+  if (task_parameters.rows()==1)
+  { 
+    task_parameters = task_parameters.row(0).replicate(n_time_steps,1).eval();
+  }
+  else if (task_parameters.cols()==1)
+  {
+    task_parameters = task_parameters.col(0).transpose().replicate(n_time_steps,1).eval();
+  }
+
+
+  
+  assert(n_time_steps==task_parameters.rows());
+  
+  int n_task_parameters = task_parameters.cols();
+  MatrixXd fa_input(n_time_steps,n_task_parameters+1);
+  fa_input << phase_state, task_parameters;
+  
+  
+  MatrixXd output(n_time_steps,1);
+  for (int dd=0; dd<dim_orig(); dd++)
+  {
+    if (function_approximator(dd)!=NULL)
+    {
+      if (function_approximator(dd)->isTrained()) 
+      {
+        function_approximator(dd)->predict(fa_input,output);
+        if (output.size()>0)
+        {
+          fa_output.col(dd) = output;
+        }
+      }
+    }
+  }
+}
+
+void  DmpContextualOneStep::train(const vector<Trajectory>& trajectories, const vector<MatrixXd>& task_parameters, string save_directory, bool overwrite)
+{
+  // Check if inputs are of the right size.
+  unsigned int n_demonstrations = trajectories.size();
+  assert(n_demonstrations==task_parameters.size());
+  
+  // Then check if the trajectories have the same duration and initial/final state
+  // Later on, if they are not the same, they should be learned also.
+  checkTrainTrajectories(trajectories);
+
+  // Set tau, initial_state and attractor_state from the trajectories 
+  set_tau(trajectories[0].duration());
+  set_initial_state(trajectories[0].initial_y());
+  set_attractor_state(trajectories[0].final_y());
+  
+  MatrixXd all_fa_inputs(0,0);
+  MatrixXd all_fa_targets(0,0);  
+  int n_task_parameters = -1;
+  int n_time_steps_total = 0;
+
+  VectorXd cur_fa_input_phase;
+  MatrixXd cur_fa_target;
+  MatrixXd cur_task_parameters;
+  for (unsigned int i_demo=0; i_demo<n_demonstrations; i_demo++)
+  {
+    cur_task_parameters = task_parameters[i_demo]; 
+    if (i_demo==0)
+    {
+      n_task_parameters = cur_task_parameters.cols();
+      
+      // This is the first time task_parameters_ is set, because this is the first time we know 
+      // n_task_parameters.
+      // We set it so that set_task_parameters can check if task_parameters_.cols()==n_task_parameters
+      task_parameters_ = MatrixXd::Zero(1,n_task_parameters);
+    }
+    else
+    {
+      assert(n_task_parameters==cur_task_parameters.cols());
+    }
+    
+    int n_time_steps = trajectories[i_demo].length();
+    n_time_steps_total += n_time_steps;
+
+    // Make sure cur_task_parameters has n_time_steps. Copy if it doesn't.
+    if (cur_task_parameters.rows()==1 && n_time_steps>1) {      
+      MatrixXd cur_task_parameters_tmp = cur_task_parameters.replicate(n_time_steps,1);
+      cur_task_parameters = cur_task_parameters_tmp;
+    }
+    assert(n_time_steps==cur_task_parameters.rows());
+    
+    computeFunctionApproximatorInputsAndTargets(trajectories[i_demo], cur_fa_input_phase, cur_fa_target);
+    
+    all_fa_inputs.conservativeResize(n_time_steps_total,1+n_task_parameters);
+    
+    all_fa_inputs.bottomLeftCorner(n_time_steps,1) = cur_fa_input_phase;
+    all_fa_inputs.bottomRightCorner(n_time_steps,n_task_parameters) = cur_task_parameters;
+
+    all_fa_targets.conservativeResize(n_time_steps_total,dim_orig());
+    all_fa_targets.bottomRows(n_time_steps) = cur_fa_target;
+    
+  }
+
+  // Now we have a vector of matrices with different numbers of rows, but the same number of 
+  // columns. We now concatenate them into one big matrix.
+  
+  for (int dd=0; dd<dim_orig(); dd++)
+  {
+    // This is just boring stuff to figure out if and where to store the results of training
+    string save_directory_dim;
+    if (!save_directory.empty())
+    {
+      if (dim_orig()==1)
+        save_directory_dim = save_directory;
+      else
+        save_directory_dim = save_directory + "/dim" + to_string(dd);
+    }
+    
+    VectorXd fa_target = all_fa_targets.col(dd);
+    function_approximator(dd)->train(all_fa_inputs,fa_target,save_directory_dim,overwrite);
+  }
+  
+}
+
+}

--- a/src/dmp/DmpContextualTwoStep.cpp
+++ b/src/dmp/DmpContextualTwoStep.cpp
@@ -20,7 +20,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
  */
-
+#define EIGEN2_SUPPORT
 #include "dmp/Dmp.hpp"
 #include "dmp/DmpContextualTwoStep.hpp"
 

--- a/src/dmp/DmpContextualTwoStep.cpp~
+++ b/src/dmp/DmpContextualTwoStep.cpp~
@@ -1,0 +1,220 @@
+/**
+ * @file DmpContextualTwoStep.cpp
+ * @brief  Contextual Dmp class source file.
+ * @author Freek Stulp
+ *
+ * This file is part of DmpBbo, a set of libraries and programs for the 
+ * black-box optimization of dynamical movement primitives.
+ * Copyright (C) 2014 Freek Stulp, ENSTA-ParisTech
+ * 
+ * DmpBbo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ * 
+ * DmpBbo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "dmp/Dmp.hpp"
+#include "dmp/DmpContextualTwoStep.hpp"
+
+#include "dmp/Trajectory.hpp"
+#include "functionapproximators/FunctionApproximator.hpp"
+#include "functionapproximators/FunctionApproximatorLWR.hpp"
+
+#include <boost/serialization/vector.hpp>
+
+#include <iostream>
+#include <eigen3/Eigen/Core>
+
+using namespace std;
+using namespace Eigen;
+
+namespace DmpBbo {
+
+DmpContextualTwoStep::DmpContextualTwoStep(int n_dims_dmp, vector<FunctionApproximator*> function_approximators, FunctionApproximator* policy_parameter_function, DmpType dmp_type) 
+:  DmpContextual(n_dims_dmp, function_approximators, dmp_type)
+{
+  policy_parameter_function_ = vector<vector<FunctionApproximator*> >(dim_orig());
+  for (int dd=0; dd<dim_orig(); dd++)
+  { 
+    policy_parameter_function_[dd] = vector<FunctionApproximator*>(1);
+    policy_parameter_function_[dd][0] = policy_parameter_function->clone();
+  }
+}
+
+// Overloads in DMP computeFunctionApproximatorOutput
+void DmpContextualTwoStep::computeFunctionApproximatorOutput(const MatrixXd& phase_state, MatrixXd& fa_output) const
+{
+  int n_time_steps = phase_state.rows(); 
+  fa_output.resize(n_time_steps,dim_orig());
+  fa_output.fill(0.0);
+  
+  if (task_parameters_.rows()==0)
+  {
+    // When the task parameters are not set, we cannot compute the output of the function approximator.
+    return;
+  }
+  
+  MatrixXd task_parameters = task_parameters_;
+  if (task_parameters.rows()==1)
+  { 
+    task_parameters = task_parameters.row(0).replicate(n_time_steps,1).eval();
+  }
+  else if (task_parameters.cols()==1)
+  {
+    task_parameters = task_parameters.col(0).transpose().replicate(n_time_steps,1).eval();
+  }
+
+  assert(n_time_steps==task_parameters.rows());
+  
+  //int n_task_parameters = task_parameters.cols();
+  
+  VectorXd model_parameters;
+  MatrixXd output(1,1);
+  for (int dd=0; dd<dim_orig(); dd++)
+  { 
+    int n_parameters = function_approximator(dd)->getParameterVectorSelectedSize();
+    model_parameters.resize(n_parameters);
+    for (int pp=0; pp<n_parameters; pp++)
+    {
+      policy_parameter_function_[dd][pp]->predict(task_parameters,output);
+      model_parameters[pp] = output(0,0);
+    }
+    function_approximator(dd)->setParameterVectorSelected(model_parameters);
+  }
+
+  // The parameters of the function_approximators have been set, get their outputs now.  
+  for (int dd=0; dd<dim_orig(); dd++)
+  {
+    function_approximator(dd)->predict(phase_state,output);
+    if (output.size()>0)
+    {
+      fa_output.col(dd) = output;
+    }
+  }
+
+}
+
+bool DmpContextualTwoStep::isTrained(void) const
+{
+  for (int dd=0; dd<dim_orig(); dd++)
+    for (unsigned int pp=0; pp<policy_parameter_function_[dd].size(); pp++)
+      if (!policy_parameter_function_[dd][pp]->isTrained())
+        return false;
+      
+  return true;   
+}
+
+void  DmpContextualTwoStep::train(const vector<Trajectory>& trajectories, const vector<MatrixXd>& task_parameters, string save_directory, bool overwrite)
+{
+  // Check if inputs are of the right size.
+  unsigned int n_demonstrations = trajectories.size();
+  assert(n_demonstrations==task_parameters.size());  
+  
+  
+  // Then check if the trajectories have the same duration and initial/final state
+  // Later on, if they are not the same, they should be learned also.
+  checkTrainTrajectories(trajectories);
+
+  // Set tau, initial_state and attractor_state from the trajectories 
+  set_tau(trajectories[0].duration());
+  set_initial_state(trajectories[0].initial_y());
+  set_attractor_state(trajectories[0].final_y());
+
+  MatrixXd cur_task_parameters;
+  VectorXd cur_model_parameters;// todo Remove redundant tmp variable
+  vector<MatrixXd> all_model_parameters(n_demonstrations); 
+  for (unsigned int i_demo=0; i_demo<n_demonstrations; i_demo++)
+  {
+    
+    string save_directory_demo;
+    if (!save_directory.empty())
+      save_directory_demo = save_directory + "/demo" + to_string(i_demo);
+    
+    Dmp::train(trajectories[i_demo],save_directory_demo,overwrite);
+    
+    for (int i_dim=0; i_dim<dim_orig(); i_dim++)
+    {
+      function_approximator(i_dim)->setSelectedParametersOne(string("slopes")); // todo Should be argument of constructor
+  
+      function_approximator(i_dim)->getParameterVectorSelected(cur_model_parameters);
+      //cout << cur_model_parameters << endl;
+      if (i_demo==0)
+        all_model_parameters[i_dim].resize(n_demonstrations,cur_model_parameters.size());
+      else
+        assert(cur_model_parameters.size()==all_model_parameters[i_dim].cols());
+
+      all_model_parameters[i_dim].row(i_demo) = cur_model_parameters;
+      
+    }
+  }
+
+   
+  // Gather task parameters in a matrix
+  int n_task_parameters = task_parameters[0].cols();
+  // This is the first time task_parameters_ is set, because this is the first time we know 
+  // n_task_parameters.
+  // We set it so that set_task_parameters can check if task_parameters_.cols()==n_task_parameters
+  task_parameters_ = MatrixXd::Zero(1,n_task_parameters);
+  
+  MatrixXd inputs(n_demonstrations,n_task_parameters);
+  for (unsigned int i_demo=0; i_demo<n_demonstrations; i_demo++)
+  {
+    if (task_parameters[i_demo].rows()>0)
+    {
+      cerr << __FILE__ << ":" << __LINE__ << ":";
+      cerr << "WARNING. For DmpContextualTwoStep, task parameters may not vary over time during training. Using task parameters at t=0 only." << endl;
+    }
+    inputs.row(i_demo) = task_parameters[i_demo].row(0);
+  }
+
+  
+  // Input to policy parameter functions: task_parameters
+  // Target for each policy parameter function: all_model_parameters.col(param)
+  
+  for (int i_dim=0; i_dim<dim_orig(); i_dim++)
+  {
+    int n_pol_pars = all_model_parameters[i_dim].cols();
+    for (int i_pol_par=1; i_pol_par<n_pol_pars; i_pol_par++)
+    {
+      policy_parameter_function_[i_dim].push_back(policy_parameter_function_[i_dim][0]->clone());
+      //cout << *(policy_parameter_function_[i_dim][i_pol_par]) << endl;
+    }
+
+    for (int i_pol_par=0; i_pol_par<n_pol_pars; i_pol_par++)
+    {
+      MatrixXd targets = all_model_parameters[i_dim].col(i_pol_par);
+      //cout << "_________________" << endl;
+      //cout << inputs.transpose() << endl << endl;
+      //cout << targets.transpose() << endl;
+      
+      string save_directory_cur;
+      if (!save_directory.empty())
+          save_directory_cur = save_directory + "/dim" + to_string(i_dim) + "_polpar" + to_string(i_pol_par);
+      
+      policy_parameter_function_[i_dim][i_pol_par]->train(inputs,targets,save_directory_cur,overwrite);
+    
+    }
+  }
+  
+  
+}
+
+template<class Archive>
+void DmpContextualTwoStep::serialize(Archive & ar, const unsigned int version)
+{
+  // serialize base class information
+  ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(DmpContextual);
+  
+  ar & BOOST_SERIALIZATION_NVP(policy_parameter_function_);
+
+}
+
+}

--- a/src/dmp/Trajectory.cpp
+++ b/src/dmp/Trajectory.cpp
@@ -20,7 +20,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
  */
-
+#define EIGEN2_SUPPORT
 #include "dmp/Trajectory.hpp"
 
 #include "dmpbbo_io/EigenFileIO.hpp"

--- a/src/dmp/Trajectory.cpp~
+++ b/src/dmp/Trajectory.cpp~
@@ -1,0 +1,269 @@
+/**
+ * @file Trajectory.cpp
+ * @brief  Trajectory class source file.
+ * @author Freek Stulp
+ *
+ * This file is part of DmpBbo, a set of libraries and programs for the 
+ * black-box optimization of dynamical movement primitives.
+ * Copyright (C) 2014 Freek Stulp, ENSTA-ParisTech
+ * 
+ * DmpBbo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ * 
+ * DmpBbo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#define EIGEN2_SUPPORT
+#include "dmp/Trajectory.hpp"
+
+#include "dmpbbo_io/EigenFileIO.hpp"
+
+#include <fstream>
+#include <iostream>
+#include <vector>
+#include <eigen3/Eigen/Core>
+
+
+using namespace std;
+using namespace Eigen;
+
+namespace DmpBbo {
+  
+Trajectory::Trajectory(void)
+{
+}
+
+Trajectory::Trajectory(const VectorXd& ts, const MatrixXd& ys,  const MatrixXd& yds,  const MatrixXd& ydds, const Eigen::MatrixXd& misc)
+: ts_(ts), ys_(ys), yds_(yds), ydds_(ydds), misc_(misc)
+{
+  int n_time_steps = ts_.rows();
+  assert(n_time_steps==ys_.rows());
+  assert(n_time_steps==yds_.rows());
+  assert(n_time_steps==ydds_.rows());
+  if (misc_.cols()==0)
+    misc_ = MatrixXd(n_time_steps,0);
+  assert(n_time_steps==misc_.rows());
+  
+  int n_dims = ys_.cols();
+  assert(n_dims==yds_.cols());
+  assert(n_dims==ydds_.cols());
+  
+    
+}
+
+void Trajectory::set_misc(const Eigen::MatrixXd& misc)
+{
+  if (misc.rows()==ts_.size())
+  {
+    // misc is of size n_time_steps X n_dims_misc
+    misc_ = misc;
+  }
+  else if (misc.rows()==1)
+  {
+    // misc is of size 1 X n_dim_misc
+    // then replicate it so that it becomes of size n_time_steps X n_dims_misc
+    misc_ = misc.replicate(ts_.size(),1);
+  }
+  else
+  {
+    cerr << __FILE__ << ":" << __LINE__ << ":";
+    cerr << "misc must have 1 or " << ts_.size() << " rows, but it has " << misc.rows() << endl;
+  }
+    
+}
+
+void Trajectory::append(const Trajectory& trajectory)
+{
+  assert(dim() == trajectory.dim());
+
+  assert(ts_[length() - 1] == trajectory.ts()[0]);
+
+  if (ys_.row(length() - 1).isZero() || trajectory.ys().row(0).isZero())
+    assert(ys_.row(length() - 1).isZero() && trajectory.ys().row(0).isZero());
+  else
+    assert(ys_.row(length() - 1).isApprox(trajectory.ys().row(0)));
+
+  if (yds_.row(length() - 1).isZero() || trajectory.yds().row(0).isZero())
+    assert(yds_.row(length() - 1).isZero() && trajectory.yds().row(0).isZero());
+  else
+    assert(yds_.row(length() - 1).isApprox(trajectory.yds().row(0)));
+
+  if (ydds_.row(length() - 1).isZero() || trajectory.ydds().row(0).isZero())
+    assert(ydds_.row(length() - 1).isZero() && trajectory.ydds().row(0).isZero());
+  else
+    assert(ydds_.row(length() - 1).isApprox(trajectory.ydds().row(0)));
+
+  int new_size = length() + trajectory.length() - 1;
+
+  VectorXd new_ts(new_size);
+  new_ts << ts_, trajectory.ts().segment(1, trajectory.length() - 1);
+  ts_ = new_ts;
+
+  MatrixXd new_ys(new_size, dim());
+  new_ys << ys_, trajectory.ys().block(1, 0, trajectory.length() - 1, dim());
+  ys_ = new_ys;
+
+  MatrixXd new_yds(new_size, dim());
+  new_yds << yds_, trajectory.yds().block(1, 0, trajectory.length() - 1, dim());
+  yds_ = new_yds;
+
+  MatrixXd new_ydds(new_size, dim());
+  new_ydds << ydds_, trajectory.ydds().block(1, 0, trajectory.length() - 1, dim());
+  ydds_ = new_ydds;
+  
+  assert(dim_misc() == trajectory.dim_misc());
+  if (dim_misc()==0)
+  {
+    misc_.resize(new_size,0);
+  }
+  else
+  {
+    MatrixXd new_misc(new_size, dim_misc());
+    new_misc << misc_, trajectory.misc().block(1, 0, trajectory.length() - 1, dim_misc());
+    misc_ = new_misc;
+  }
+}
+
+Trajectory Trajectory::generateMinJerkTrajectory(const VectorXd& ts, const VectorXd& y_from, const VectorXd& y_to)
+{
+  int n_time_steps = ts.size();
+  int n_dims = y_from.size();
+  
+  MatrixXd ys(n_time_steps,n_dims), yds(n_time_steps,n_dims), ydds(n_time_steps,n_dims);
+  
+  double D =  ts[n_time_steps-1];
+  ArrayXd tss = (ts/D).array(); 
+    
+
+  ArrayXd A = y_to.array()-y_from.array();
+  
+  for (int i_dim=0; i_dim<n_dims; i_dim++)
+  {
+    
+    // http://noisyaccumulation.blogspot.fr/2012/02/how-to-decompose-2d-trajectory-data.html
+    
+    ys.col(i_dim)   = y_from[i_dim] + A[i_dim]*(  6*tss.pow(5)  -15*tss.pow(4) +10*tss.pow(3));
+    
+    yds.col(i_dim)  =             (A[i_dim]/D)*( 30*tss.pow(4)  -60*tss.pow(3) +30*tss.pow(2));
+    
+    ydds.col(i_dim) =         (A[i_dim]/(D*D))*(120*tss.pow(3) -180*tss.pow(2) +60*tss       );
+  }
+  
+  return Trajectory(ts,ys,yds,ydds);
+ 
+  
+}
+
+Trajectory Trajectory::generatePolynomialTrajectory(const VectorXd& ts, const VectorXd& y_from, const VectorXd& yd_from, const VectorXd& ydd_from,
+  const VectorXd& y_to, const VectorXd& yd_to, const VectorXd& ydd_to)
+{
+  VectorXd a0 = y_from;
+  VectorXd a1 = yd_from;
+  VectorXd a2 = ydd_from / 2;
+
+  VectorXd a3 = -10 * y_from - 6 * yd_from - 2.5 * ydd_from + 10 * y_to - 4 * yd_to + 0.5 * ydd_to;
+  VectorXd a4 = 15 * y_from + 8 * yd_from + 2 * ydd_from - 15  * y_to  + 7 * yd_to - ydd_to;
+  VectorXd a5 = -6 * y_from - 3 * yd_from - 0.5 * ydd_from  + 6 * y_to  - 3 * yd_to + 0.5 * ydd_to;
+
+  int n_time_steps = ts.size();
+  int n_dims = y_from.size();
+  
+  MatrixXd ys(n_time_steps,n_dims), yds(n_time_steps,n_dims), ydds(n_time_steps,n_dims);
+
+  for (int i = 0; i < ts.size(); i++)
+  {
+    double t = (ts[i] - ts[0]) / (ts[n_time_steps - 1] - ts[0]);
+    ys.row(i) = a0 + a1 * t + a2 * pow(t, 2) + a3 * pow(t, 3) + a4 * pow(t, 4) + a5 * pow(t, 5);
+    yds.row(i) = a1 + 2 * a2 * t + 3 * a3 * pow(t, 2) + 4 * a4 * pow(t, 3) + 5 * a5 * pow(t, 4);
+    ydds.row(i) = 2 * a2 + 6 * a3 * t + 12 * a4 * pow(t, 2) + 20 * a5 * pow(t, 3);
+  }
+
+  yds /= (ts[n_time_steps - 1] - ts[0]);
+  ydds /= pow(ts[n_time_steps - 1] - ts[0], 2);
+
+  return Trajectory(ts, ys, yds, ydds);
+}
+
+Trajectory Trajectory::generatePolynomialTrajectoryThroughViapoint(const VectorXd& ts, const VectorXd& y_from, const VectorXd& y_yd_ydd_viapoint, double viapoint_time, const VectorXd& y_to)
+{
+  
+  int n_dims = y_from.size();
+  assert(n_dims==y_to.size());
+  assert(3*n_dims==y_yd_ydd_viapoint.size()); // Contains y, yd and ydd, so *3
+  
+  int n_time_steps = ts.size();
+  
+  int viapoint_time_step = 0;
+  while (viapoint_time_step<n_time_steps && ts[viapoint_time_step]<viapoint_time)
+    viapoint_time_step++;
+  
+  if (viapoint_time_step>=n_time_steps)
+  {
+    cerr << __FILE__ << ":" << __LINE__ << ":";
+    cerr << "ERROR: the time vector does not contain any time smaller than " << viapoint_time << ". Returning min-jerk trajectory WITHOUT viapoint." <<  endl;
+    return Trajectory();
+  }
+
+  VectorXd yd_from        = VectorXd::Zero(n_dims);
+  VectorXd ydd_from       = VectorXd::Zero(n_dims);
+
+  VectorXd y_viapoint     = y_yd_ydd_viapoint.segment(0*n_dims,n_dims);
+  VectorXd yd_viapoint    = y_yd_ydd_viapoint.segment(1*n_dims,n_dims);
+  VectorXd ydd_viapoint   = y_yd_ydd_viapoint.segment(2*n_dims,n_dims);
+
+  VectorXd yd_to          = VectorXd::Zero(n_dims);
+  VectorXd ydd_to         = VectorXd::Zero(n_dims);
+
+  Trajectory traj = Trajectory::generatePolynomialTrajectory(ts.segment(0, viapoint_time_step + 1), y_from, yd_from, ydd_from, y_viapoint, yd_viapoint, ydd_viapoint);
+  traj.append(Trajectory::generatePolynomialTrajectory(ts.segment(viapoint_time_step, n_time_steps - viapoint_time_step), y_viapoint, yd_viapoint, ydd_viapoint, y_to, yd_to, ydd_to));
+
+  return traj;
+}
+
+
+ostream& operator<<(ostream& output, const Trajectory& trajectory) {
+  MatrixXd traj_matrix(trajectory.length(),1+3*trajectory.dim()+trajectory.dim_misc());
+  traj_matrix << trajectory.ts_, trajectory.ys_, trajectory.yds_, trajectory.ydds_, trajectory.misc_; 
+  output << traj_matrix << endl;
+  return output;
+}
+
+bool Trajectory::saveToFile(string directory, string filename, bool overwrite) const
+{/*
+  MatrixXd traj_matrix(length(),1+3*dim()+dim_misc());
+  traj_matrix << ts_, ys_, yds_, ydds_, misc_; 
+  return saveMatrix(directory, filename, traj_matrix, overwrite);  
+*/}
+
+Trajectory Trajectory::readFromFile(string filename, int n_dims_misc)
+{/*
+  MatrixXd traj_matrix;
+  if (!loadMatrix(filename,traj_matrix))
+  { 
+    cerr << __FILE__ << ":" << __LINE__ << ":";
+    cerr << "Cannot open filename '"<< filename <<"'." << endl;
+    return Trajectory();
+  }
+  
+  int n_dims       = (traj_matrix.cols()-1-n_dims_misc)/3;
+  int n_time_steps = traj_matrix.rows();
+  VectorXd ts; 
+  MatrixXd ys, yds, ydds, misc;
+  ts   = traj_matrix.block(0,0+0*n_dims,n_time_steps,1);
+  ys   = traj_matrix.block(0,1+0*n_dims,n_time_steps,n_dims);
+  yds  = traj_matrix.block(0,1+1*n_dims,n_time_steps,n_dims);
+  ydds = traj_matrix.block(0,1+2*n_dims,n_time_steps,n_dims);
+  misc = traj_matrix.block(0,1+3*n_dims,n_time_steps,n_dims_misc);
+  
+  return Trajectory(ts,ys,yds,ydds,misc);
+*/
+}
+
+}

--- a/src/dmp/Trajectory.hpp
+++ b/src/dmp/Trajectory.hpp
@@ -23,9 +23,10 @@
 
 #ifndef _TRAJECTORY_H_
 #define _TRAJECTORY_H_
+#define EIGEN2_SUPPORT
 
-#include <iosfwd>
 #include <eigen3/Eigen/Core>
+#include <iosfwd>
 
 #include <boost/serialization/access.hpp>
 #include "dmpbbo_io/EigenBoostSerialization.hpp"

--- a/src/dmp/Trajectory.hpp~
+++ b/src/dmp/Trajectory.hpp~
@@ -1,0 +1,237 @@
+/**
+ * @file Trajectory.hpp
+ * @brief  Trajectory class header file.
+ * @author Freek Stulp, Thibaut Munzer
+ *
+ * This file is part of DmpBbo, a set of libraries and programs for the 
+ * black-box optimization of dynamical movement primitives.
+ * Copyright (C) 2014 Freek Stulp, ENSTA-ParisTech
+ * 
+ * DmpBbo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ * 
+ * DmpBbo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef _TRAJECTORY_H_
+#define _TRAJECTORY_H_
+//#define EIGEN2_SUPPORT
+
+#include <eigen3/Eigen/Core>
+#include <iosfwd>
+
+#include <boost/serialization/access.hpp>
+#include "dmpbbo_io/EigenBoostSerialization.hpp"
+
+
+namespace DmpBbo {
+
+/** \brief A class for storing trajectories, i.e. positions, velocities and accelerations of
+ *  variables over time.
+ *
+ * A trajectory is essentially a matrix of following form:
+\verbatim
+t_0   x^0_0 x^1_0 .. x^D_0   xd^0_0 xd^1_0 .. xd^D_0   xdd^0_0 xdd^1_0 ... xdd^D_0
+t_1   x^0_1 x^1_1 .. x^D_1   xd^0_1 xd^1_1 .. xd^D_1   xdd^0_1 xdd^1_1 ... xdd^D_1
+ :       :     :       :         :      :       :         :       :           :
+t_T   x^0_T x^1_T .. x^D_T   xd^0_T xd^1_T .. xd^D_T   xdd^0_T xdd^1_T ... xdd^D_T
+\endverbatim
+For each time t_0 to t_T it contains the positions, velocities and accelerations of a D-dimensional state.
+ */
+class Trajectory
+{
+public:
+  /** Default constructor.
+   */
+  Trajectory(void);
+  
+  /** Initializing constructor.
+   * \param[in] ts Times
+   * \param[in] ys Positions
+   * \param[in] yds Velocities 
+   * \param[in] ydds Acceleration
+   * \param[in] misc Miscellaneous other variables which you may add if necessary
+   */
+   Trajectory(const Eigen::VectorXd& ts, const Eigen::MatrixXd& ys,  const Eigen::MatrixXd& yds,  const Eigen::MatrixXd& ydds, const Eigen::MatrixXd& misc=Eigen::MatrixXd(0,0));
+
+  /** Accessor function for the times at which measurements were made.
+   * \return Times at which measurements were made.
+   */
+  inline const Eigen::VectorXd& ts(void) const { return ts_; }
+  
+  /** Accessor function for the positions at different times
+   * \return Positions at different times
+   */
+  inline const Eigen::MatrixXd& ys(void) const { return ys_; }
+  
+  /** Accessor function for the velocities at different times
+   * \return Velocities at different times
+   */   
+  inline const Eigen::MatrixXd& yds(void) const { return yds_; }
+  
+  /** Accessor function for the accelerations at different times
+   * \return Accelerations at different times
+   */
+  inline const Eigen::MatrixXd& ydds(void) const { return ydds_; }
+  
+  /** Return miscellaneous variables included in the trajectory.
+   * This can be used for instance to store task paramaters for each time step alongside the
+   * values of the trajectory variables at each time step.
+   * \return Matrix of miscellaneous variables, of size n_time_steps X n_misc_variables
+   */
+  inline const Eigen::MatrixXd& misc(void) const { return misc_; }
+  
+  /** Set miscellaneous variables included in the trajectory.
+   * This can be used for instance to set task paramaters for each time step alongside the
+   * values of the trajectory variables at each time step.
+   * \param[in] misc Matrix of miscellaneous variables, of size n_time_steps X n_misc_variables
+   */
+  void set_misc(const Eigen::MatrixXd& misc);
+  
+  /** Get the length of the trajectory, i.e. the number of time steps. 
+   * \return The number of time steps
+   */  
+  inline int length(void) const { return ts_.size(); }
+  
+  /** Get the duration of the trajectory in seconds.
+   * \return The duration of the trajecory in seconds.
+   */  
+  inline double duration(void) const {  return (ts_[ts_.size()-1]-ts_[0]); }
+  
+  /** Get the dimensionality of the trajectory. 
+   * \return The dimensionality of the trajectory.
+   */  
+  inline int dim(void) const { return ys_.cols(); }
+  
+  /** Get the dimensionality of the  misc variables. 
+   * \return The dimensionality of the misc variables.
+   */  
+  inline int dim_misc(void) const { return misc_.cols(); }
+  
+  /** Get the first state, i.e. at t=0, in the trajectory (only positions).
+   *  \return First state in the trajectory.
+   */
+  inline Eigen::VectorXd initial_y(void) const { return ys_.row(0); }
+
+  /** Get the last state, i.e. at t=T, in the trajectory (only positions).
+   *  \return Last state in the trajectory.
+   */
+  inline Eigen::VectorXd final_y(void) const { return ys_.row(ys_.rows()-1); }
+  
+  /** Append another trajectory at the end. The appended trajectory should begin as current trajectory ends, in terms of time, position, velocity an acceleration.
+   *
+   * \param[in] trajectory Trajectory to append.
+   */
+  void append(const Trajectory& trajectory);
+  
+  /** Write object to an output stream.
+   *
+   *  \param[in] output  Output stream to which to write to
+   *  \param[in] trajectory Trajectory to write
+   *  \return    Output stream
+   */
+  friend std::ostream& operator<<(std::ostream& output, const Trajectory& trajectory);
+
+  /** Save a trajectory to a file
+   * \param[in] directory Directory to which to save trajectory to
+   * \param[in] filename Filename
+   * \param[in] overwrite Whether to overwrite existing files (true=overwrite, false=give warning)
+   * \return true if writing was successful, false otherwise.
+   */
+  bool saveToFile(std::string directory, std::string filename, bool overwrite=false) const;
+
+  //friend std::istream& operator>>(std::istream& input, Trajectory& trajectory);
+  
+  /** Read a trajectory from a file.
+   *
+   *  \param[in] filename The name of the file from which to read.
+   *  \param[in] n_dims_misc Number of miscellaneous variables. This is needed because the file contains a n_time_steps x N matrix, and we need to know which part of M represents the miscellaneous variables, and which part represents the trajectory. 
+   *  \return Trajectory that was read
+   *
+   *  \todo Replace this with >>operator
+   */
+  static Trajectory readFromFile(std::string filename, int n_dims_misc=0);
+  
+  /** Generate a minimum-jerk trajectory from an initial to a final state.
+   *
+   * Velocities and accelerations are 0 at initial and final state.
+   * 
+   * \param[in] ts Times at which the state should be computed.
+   * \param[in] initial_y Initial position of the trajectory. 
+   * \param[in] final_y Final position of the trajectory. 
+   * \return The minimum-jerk trajectory from initial_y to final_y
+   *
+   * See http://noisyaccumulation.blogspot.fr/2012/02/how-to-decompose-2d-trajectory-data.html
+   */
+  static Trajectory generateMinJerkTrajectory(const Eigen::VectorXd& ts, const Eigen::VectorXd& initial_y, const Eigen::VectorXd& final_y);
+
+
+  /** Generate a fifth order polynomial trajectory from an initial to a final state.
+   *
+   * \param[in] ts Times at which the state should be computed.
+   * \param[in] y_from Initial position of the trajectory. 
+   * \param[in] yd_from Initial velocity of the trajectory. 
+   * \param[in] ydd_from Initial acceleration of the trajectory. 
+   * \param[in] y_to Final position of the trajectory. 
+   * \param[in] yd_to Final velocity of the trajectory. 
+   * \param[in] ydd_to Final acceleration of the trajectory. 
+   * \return The trajectory
+   */
+  static Trajectory generatePolynomialTrajectory(const Eigen::VectorXd& ts, const Eigen::VectorXd& y_from, const Eigen::VectorXd& yd_from, const Eigen::VectorXd& ydd_from,
+    const Eigen::VectorXd& y_to, const Eigen::VectorXd& yd_to, const Eigen::VectorXd& ydd_to);
+    
+  /** Generate a trajectory from an initial to a final state, through a viapoint.
+   * 
+   * \param[in] ts Times at which the state should be computed.
+   * \param[in] y_from Initial position of the trajectory. 
+   * \param[in] y_yd_ydd_viapoint Viapoint, should contain, pos, vel and acc. 
+   * \param[in] viapoint_time Time at which the trajectory should pass through the viapoint. 
+   * \param[in] y_to Final position of the trajectory. 
+   * \return The trajectory from y_from to y_to, through the viapoint 
+   */
+  static Trajectory generatePolynomialTrajectoryThroughViapoint(const Eigen::VectorXd& ts, const Eigen::VectorXd& y_from, const Eigen::VectorXd& y_yd_ydd_viapoint, double viapoint_time, const Eigen::VectorXd& y_to);
+
+private:
+  Eigen::VectorXd ts_;
+  Eigen::MatrixXd ys_;
+  Eigen::MatrixXd yds_;
+  Eigen::MatrixXd ydds_;
+  Eigen::MatrixXd misc_;
+
+  /** Give boost serialization access to private members. */  
+  friend class boost::serialization::access;
+  
+  /** Serialize class data members to boost archive. 
+   * \param[in] ar Boost archive
+   * \param[in] version Version of the class
+   * See http://www.boost.org/doc/libs/1_55_0/libs/serialization/doc/tutorial.html#simplecase
+   */
+  template<class Archive>
+  void serialize(Archive & ar, const unsigned int version)
+  {
+    ar & BOOST_SERIALIZATION_NVP(ts_);
+    ar & BOOST_SERIALIZATION_NVP(ys_);
+    ar & BOOST_SERIALIZATION_NVP(yds_);
+    ar & BOOST_SERIALIZATION_NVP(ydds_);
+    ar & BOOST_SERIALIZATION_NVP(misc_);
+  }
+
+};
+
+}
+
+#include <boost/serialization/level.hpp>
+/** Don't add version information to archives. */
+BOOST_CLASS_IMPLEMENTATION(DmpBbo::Trajectory,boost::serialization::object_serializable);
+
+#endif
+
+

--- a/src/dmp_bbo/TaskSolverDmp.cpp
+++ b/src/dmp_bbo/TaskSolverDmp.cpp
@@ -20,7 +20,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
  */
-
+#define EIGEN2_SUPPORT
 #include "dmp_bbo/TaskSolverDmp.hpp"
 
 

--- a/src/dmp_bbo/TaskSolverDmp.cpp~
+++ b/src/dmp_bbo/TaskSolverDmp.cpp~
@@ -1,0 +1,157 @@
+/**
+ * @file   TaskSolverDmp.cpp
+ * @brief  TaskSolverDmp class source file.
+ * @author Freek Stulp
+ *
+ * This file is part of DmpBbo, a set of libraries and programs for the 
+ * black-box optimization of dynamical movement primitives.
+ * Copyright (C) 2014 Freek Stulp, ENSTA-ParisTech
+ * 
+ * DmpBbo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ * 
+ * DmpBbo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "dmp_bbo/TaskSolverDmp.hpp"
+
+
+
+
+
+#include <boost/serialization/export.hpp>
+#include <boost/archive/text_iarchive.hpp>
+#include <boost/archive/text_oarchive.hpp>
+#include <boost/archive/xml_iarchive.hpp>
+#include <boost/archive/xml_oarchive.hpp>
+#include "dmp_bbo/TaskSolverDmp.hpp"
+
+BOOST_CLASS_EXPORT_IMPLEMENT(DmpBbo::TaskSolverDmp);
+
+#include <boost/serialization/base_object.hpp>
+
+#include <iostream>
+#include <string>
+#include <set>
+#include <eigen3/Eigen/Core>
+
+#include "dmpbbo_io/EigenBoostSerialization.hpp"
+#include "dmpbbo_io/BoostSerializationToString.hpp"
+#include "dmp/Dmp.hpp"
+
+using namespace std;
+using namespace Eigen;
+
+namespace DmpBbo {
+  
+TaskSolverDmp::TaskSolverDmp(Dmp* dmp, set<string> optimize_parameters, double dt, double integrate_dmp_beyond_tau_factor, bool use_normalized_parameter)
+: dmp_(dmp)
+{
+  dmp_->setSelectedParameters(optimize_parameters);
+  
+  integrate_time_ = dmp_->tau() * integrate_dmp_beyond_tau_factor;
+  n_time_steps_ = (integrate_time_/dt)+1;
+  use_normalized_parameter_ = use_normalized_parameter;
+}
+
+void TaskSolverDmp::set_perturbation(double perturbation_standard_deviation)
+{
+  dmp_->set_perturbation_analytical_solution(perturbation_standard_deviation);
+}
+
+  
+void TaskSolverDmp::performRollouts(const vector<MatrixXd>& samples, const MatrixXd& task_parameters, MatrixXd& cost_vars) const 
+{
+  // n_dofs-D Dmp, n_parallel=n_dofs
+  //                   vector<Matrix>            Matrix
+  // samples         = n_dofs x          n_samples x sum(nmodel_parameters_)
+  // task_parameters =                   n_samples x n_task_pars
+  // cost_vars       =                   n_samples x (n_time_steps*n_cost_vars)
+  
+  int n_dofs = samples.size();
+  assert(n_dofs>0);
+  assert(n_dofs==dmp_->dim_orig());
+  
+  int n_samples = samples[0].rows();
+  for (int dd=1; dd<n_dofs; dd++)
+  {
+    assert(samples[dd].rows()==n_samples);
+  }
+
+  VectorXd ts = VectorXd::LinSpaced(n_time_steps_,0.0,integrate_time_);
+  
+  int n_cost_vars = 4*n_dofs+1;
+  cost_vars.resize(n_samples,n_time_steps_*n_cost_vars); 
+    
+  vector<VectorXd> model_parameters_vec(n_dofs);
+  for (int k=0; k<n_samples; k++)
+  {
+    for (int dd=0; dd<n_dofs; dd++)
+      model_parameters_vec[dd] = samples[dd].row(k);
+    dmp_->setParameterVectorSelected(model_parameters_vec, use_normalized_parameter_);
+    
+    int n_dims = dmp_->dim(); // Dimensionality of the system
+    MatrixXd xs_ana(n_time_steps_,n_dims);
+    MatrixXd xds_ana(n_time_steps_,n_dims);
+    MatrixXd forcing_terms(n_time_steps_,n_dofs);
+    forcing_terms.fill(0.0);
+    dmp_->analyticalSolution(ts,xs_ana,xds_ana,forcing_terms);
+
+    /*    
+    // Here's the non-analytical version, which is slower.
+    MatrixXd xs(n_time_steps_,n_dims);
+    MatrixXd xds(n_time_steps_,n_dims);
+    
+    // Use integrateStart to get the initial x and xd
+    VectorXd x(n_dims);
+    VectorXd xd(n_dims);
+    dmp_->integrateStart(x,xd);
+    xs.row(0)  = x.transpose();
+    xds.row(0)  = xd.transpose();
+    // Use DynamicalSystemSystem::integrateStep to integrate numerically step-by-step
+    double dt = ts[1]-ts[0];
+    for (int ii=1; ii<n_time_steps_; ii++)
+    {
+      dmp_->integrateStep(dt,x,           x,          xd); 
+      //                     previous x   updated x   updated xd
+      xs.row(ii)  = x.transpose();
+      xds.row(ii)  = xd.transpose();
+    }
+    MatrixXd ys;
+    MatrixXd yds;
+    MatrixXd ydds;
+    dmp_->statesAsTrajectory(xs,xds,ys,yds,ydds);
+    */
+
+    
+    MatrixXd ys_ana;
+    MatrixXd yds_ana;
+    MatrixXd ydds_ana;
+    dmp_->statesAsTrajectory(xs_ana,xds_ana,ys_ana,yds_ana,ydds_ana);
+    
+    int offset = 0;
+    for (int tt=0; tt<n_time_steps_; tt++)
+    {
+      cost_vars.block(k,offset,1,n_dofs) = ys_ana.row(tt);   offset += n_dofs; 
+      cost_vars.block(k,offset,1,n_dofs) = yds_ana.row(tt);  offset += n_dofs; 
+      cost_vars.block(k,offset,1,n_dofs) = ydds_ana.row(tt); offset += n_dofs; 
+      cost_vars.block(k,offset,1,1) = ts.row(tt);       offset += 1; 
+      cost_vars.block(k,offset,1,n_dofs) = forcing_terms.row(tt); offset += n_dofs;       
+    }
+  }
+}
+
+string TaskSolverDmp::toString(void) const
+{
+  RETURN_STRING_FROM_BOOST_SERIALIZATION_XML("TaskSolverDmp");
+}
+
+}

--- a/src/dmp_bbo/TaskSolverDmp.hpp
+++ b/src/dmp_bbo/TaskSolverDmp.hpp
@@ -23,7 +23,7 @@
  
 #ifndef TaskSolverDmp_H
 #define TaskSolverDmp_H
-
+#define EIGEN2_SUPPORT
 #include <string>
 #include <set>
 #include <eigen3/Eigen/Core>

--- a/src/dmp_bbo/TaskSolverDmp.hpp~
+++ b/src/dmp_bbo/TaskSolverDmp.hpp~
@@ -1,0 +1,109 @@
+/**
+ * @file   TaskSolverDmp.hpp
+ * @brief  TaskSolverDmp class header file.
+ * @author Freek Stulp
+ *
+ * This file is part of DmpBbo, a set of libraries and programs for the 
+ * black-box optimization of dynamical movement primitives.
+ * Copyright (C) 2014 Freek Stulp, ENSTA-ParisTech
+ * 
+ * DmpBbo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ * 
+ * DmpBbo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
+#ifndef TaskSolverDmp_H
+#define TaskSolverDmp_H
+
+#include <string>
+#include <set>
+#include <eigen3/Eigen/Core>
+
+#include "dmp_bbo/TaskSolverParallel.hpp"
+
+#include "dmpbbo_io/EigenBoostSerialization.hpp"
+
+namespace DmpBbo {
+  
+// Forward definition
+class Dmp;
+
+/** Task solver for the viapoint task, that generates trajectories with a DMP. 
+ */
+class TaskSolverDmp : public TaskSolverParallel
+{
+private:
+  Dmp* dmp_;
+  int n_time_steps_;
+  double integrate_time_;
+  bool use_normalized_parameter_;
+  
+public:
+  /** Constructor.
+   * \param[in] dmp The Dmp to integrate for generating trajectories (that should go through viapoints)
+   * \param[in] optimize_parameters The model parameters to change in the Dmp,  cf. sec_fa_changing_modelparameters. Depends on the function approximator used for the forcing term.
+   * \param[in] dt Integration time steps
+   * \param[in] integrate_dmp_beyond_tau_factor If you want to integrate the Dmp for a longer duration than the tau with which it was trained, set this value larger than 1. I.e. integrate_dmp_beyond_tau_factor=1.5 will integrate for 3 seconds, if the original tau of the Dmp was 2.
+   * \param[in] use_normalized_parameter Use normalized parameters, cf. sec_fa_changing_modelparameters
+   */
+  TaskSolverDmp(Dmp* dmp, std::set<std::string> optimize_parameters, double dt=0.01, double integrate_dmp_beyond_tau_factor=1.0, bool use_normalized_parameter=false);
+    
+  virtual void performRollouts(const std::vector<Eigen::MatrixXd>& samples, const Eigen::MatrixXd& task_parameters, Eigen::MatrixXd& cost_vars) const;
+  
+  /** Returns a string representation of the object.
+   * \return A string representation of the object.
+   */
+	std::string toString(void) const;
+
+  void set_perturbation(double perturbation_standard_deviation);
+
+private:
+  /**
+   * Default constructor.
+   * \remarks This default constuctor is required for boost::serialization to work. Since this
+   * constructor should not be called by other classes, it is private (boost::serialization is a
+   * friend)
+   */
+  TaskSolverDmp(void) {};
+
+  /** Give boost serialization access to private members. */  
+  friend class boost::serialization::access;
+  
+  /** Serialize class data members to boost archive. 
+   * \param[in] ar Boost archive
+   * \param[in] version Version of the class
+   * See http://www.boost.org/doc/libs/1_55_0/libs/serialization/doc/tutorial.html#simplecase
+   */
+  template<class Archive>
+  void serialize(Archive & ar, const unsigned int version)
+  {
+    // serialize base class information
+    ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(TaskSolverParallel);
+    
+    ar & BOOST_SERIALIZATION_NVP(dmp_);
+    ar & BOOST_SERIALIZATION_NVP(n_time_steps_);    
+    ar & BOOST_SERIALIZATION_NVP(integrate_time_);
+    ar & BOOST_SERIALIZATION_NVP(use_normalized_parameter_);
+  }
+
+};
+
+}
+
+#include <boost/serialization/export.hpp>
+/** Register this derived class. */
+BOOST_CLASS_EXPORT_KEY2(DmpBbo::TaskSolverDmp, "TaskSolverDmp")
+
+/** Don't add version information to archives. */
+BOOST_CLASS_IMPLEMENTATION(DmpBbo::TaskSolverDmp,boost::serialization::object_serializable);
+
+#endif

--- a/src/dmp_bbo/TaskSolverParallel.hpp
+++ b/src/dmp_bbo/TaskSolverParallel.hpp
@@ -23,7 +23,7 @@
  
 #ifndef TASK_SOLVER_PARALLEL_H
 #define TASK_SOLVER_PARALLEL_H
-
+#define EIGEN2_SUPPORT
 #include "bbo/TaskSolver.hpp"
 
 #include <vector>

--- a/src/dmp_bbo/TaskSolverParallel.hpp~
+++ b/src/dmp_bbo/TaskSolverParallel.hpp~
@@ -1,0 +1,124 @@
+/**
+ * @file   TaskSolverParallel.hpp
+ * @brief  TaskSolverParallel class header file.
+ * @author Freek Stulp
+ *
+ * This file is part of DmpBbo, a set of libraries and programs for the 
+ * black-box optimization of dynamical movement primitives.
+ * Copyright (C) 2014 Freek Stulp, ENSTA-ParisTech
+ * 
+ * DmpBbo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ * 
+ * DmpBbo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
+#ifndef TASK_SOLVER_PARALLEL_H
+#define TASK_SOLVER_PARALLEL_H
+
+#include "bbo/TaskSolver.hpp"
+
+#include <vector>
+#include <eigen3/Eigen/Core>
+
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/base_object.hpp>
+#include <boost/serialization/nvp.hpp>
+
+namespace DmpBbo {
+
+/** Interface for classes that can perform rollouts.
+ * For further information see the section on \ref sec_bbo_task_and_task_solver
+ */
+ class TaskSolverParallel : public TaskSolver
+{
+public:
+    
+  /** Perform rollouts, i.e. given a set of samples, determine all the variables that are relevant to evaluating the cost function. 
+   * \param[in] samples The samples
+   * \param[in] task_parameters The parameters of the task
+   * \param[out] cost_vars The variables relevant to computing the cost.
+   * \todo Compare to other functions
+   */
+  inline void performRollouts(const Eigen::MatrixXd& samples, const Eigen::MatrixXd& task_parameters, Eigen::MatrixXd& cost_vars) const 
+  {
+    std::vector<Eigen::MatrixXd> samples_vec(1);
+    samples_vec[0] = samples;
+    performRollouts(samples_vec, cost_vars);
+  };
+  
+  /** Perform rollouts, i.e. given a set of samples, determine all the variables that are relevant
+   * to evaluating the cost function. 
+   * This version does so for parallel optimization, where multiple distributions are updated.
+   * \param[in] samples_vec The samples, a vector with one element per distribution
+   * \param[out] cost_vars The variables relevant to computing the cost.
+   * \todo Compare to other functions
+   */
+  void performRollouts(const std::vector<Eigen::MatrixXd>& samples_vec, Eigen::MatrixXd& cost_vars) const 
+  {
+    Eigen::MatrixXd task_parameters(0,0);
+    performRollouts(samples_vec,task_parameters,cost_vars);
+  }
+  
+  /** Perform rollouts, i.e. given a set of samples, determine all the variables that are relevant
+   * to evaluating the cost function. 
+   * This version does so for parallel optimization, where multiple distributions are updated.
+   * \param[in] samples_vec The samples, a vector with one element per distribution
+   * \param[in] task_parameters The parameters of the task
+   * \param[out] cost_vars The variables relevant to computing the cost.
+   * \todo Compare to other functions
+   */
+  virtual void performRollouts(const std::vector<Eigen::MatrixXd>& samples_vec, const Eigen::MatrixXd& task_parameters, Eigen::MatrixXd& cost_vars) const = 0;
+  
+  /** Print a TaskSolver to an output stream. 
+   *
+   *  \param[in] output  Output stream to which to write to
+   *  \param[in] task_solver TaskSolver to write
+   *  \return    Output stream
+   *
+   *  \remark Calls virtual function TaskSolver::toString, which must be implemented by
+   * subclasses: http://stackoverflow.com/questions/4571611/virtual-operator
+   */ 
+  friend std::ostream& operator<<(std::ostream& output, const TaskSolverParallel& task_solver) {
+    output << task_solver.toString();
+    return output;
+  }
+  
+private:
+  /** Give boost serialization access to private members. */  
+  friend class boost::serialization::access;
+  
+  /** Serialize class data members to boost archive. 
+   * \param[in] ar Boost archive
+   * \param[in] version Version of the class
+   * See http://www.boost.org/doc/libs/1_55_0/libs/serialization/doc/tutorial.html#simplecase
+   */
+  template<class Archive>
+  void serialize(Archive & ar, const unsigned int version)
+  {
+    // serialize base class information
+    ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(TaskSolver);
+  }
+  
+};
+  
+} // namespace DmpBbo
+
+#include <boost/serialization/assume_abstract.hpp>
+/** Don't add version information to archives. */
+BOOST_SERIALIZATION_ASSUME_ABSTRACT(DmpBbo::TaskSolverParallel);
+ 
+#include <boost/serialization/export.hpp>
+/** Don't add version information to archives. */
+BOOST_CLASS_IMPLEMENTATION(DmpBbo::TaskSolverParallel,boost::serialization::object_serializable);
+
+#endif
+

--- a/src/dmp_bbo/TaskWithTrajectoryDemonstrator.hpp
+++ b/src/dmp_bbo/TaskWithTrajectoryDemonstrator.hpp
@@ -23,7 +23,7 @@
 
 #ifndef TASKWITHTRAJECTORYDEMONSTRATOR_H
 #define TASKWITHTRAJECTORYDEMONSTRATOR_H
-
+#define EIGEN2_SUPPORT
 #include "bbo/Task.hpp"
 #include "bbo/DistributionGaussian.hpp"
 #include "dmp/Trajectory.hpp"

--- a/src/dmp_bbo/TaskWithTrajectoryDemonstrator.hpp~
+++ b/src/dmp_bbo/TaskWithTrajectoryDemonstrator.hpp~
@@ -1,0 +1,153 @@
+/**
+ * @file   TaskWithTrajectoryDemonstrator.hpp
+ * @brief  TaskWithTrajectoryDemonstrator class header file.
+ * @author Freek Stulp
+ *
+ * This file is part of DmpBbo, a set of libraries and programs for the 
+ * black-box optimization of dynamical movement primitives.
+ * Copyright (C) 2014 Freek Stulp, ENSTA-ParisTech
+ * 
+ * DmpBbo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ * 
+ * DmpBbo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef TASKWITHTRAJECTORYDEMONSTRATOR_H
+#define TASKWITHTRAJECTORYDEMONSTRATOR_H
+
+#include "bbo/Task.hpp"
+#include "bbo/DistributionGaussian.hpp"
+#include "dmp/Trajectory.hpp"
+
+#include <vector>
+#include <eigen3/Eigen/Core>
+
+#include <boost/serialization/access.hpp>
+
+namespace DmpBbo {
+  
+/** Interface for tasks that are able to provide demonstrations that solve the task (optimally).
+ * Such tasks must implement the pure virtual function TaskWithTrajectoryDemonstrator::generateDemonstration(), which takes task_parmetersm and returns a demonstration. 
+ */
+class TaskWithTrajectoryDemonstrator : public Task
+{
+public:
+  /** Generate one (optimal) demonstration for this task.
+   * \param[in] task_parameters The task parameters for which to generate a demonstration. A matrix of size T X D, where T is the number of time steps, and D is the number of task parameters. If T=1, the task parameters are assumed to be constant over time.
+   * \param[in] ts The times at which to sample the trajectory
+   * \param[out] demonstration The demonstration trajectory
+   */
+  virtual void generateDemonstration(const Eigen::MatrixXd& task_parameters, const Eigen::VectorXd& ts, Trajectory& demonstration) const = 0;
+  
+  /** Generate a set of demonstrations for this task.
+   * \param[in] task_parameters The task parameters for which to generate demonstrations
+   * \param[in] ts The times at which to sample the trajectory
+   * \param[out] demonstrations The demonstrations (a vector of trajectories)
+   */
+  void generateDemonstrations(const std::vector<Eigen::MatrixXd>& task_parameters, const std::vector<Eigen::VectorXd>& ts, std::vector<Trajectory>& demonstrations) const
+  {
+    unsigned int n_demos = task_parameters.size();
+    assert(n_demos==ts.size());
+    
+    demonstrations = std::vector<Trajectory>(n_demos);
+    for (unsigned int i_demo=0; i_demo<n_demos; i_demo++)
+    {
+      generateDemonstration(task_parameters[i_demo], ts[i_demo], demonstrations[i_demo]); 
+    }
+    
+  }
+  
+  /** Generate a set of demonstrations for this task.
+   * \param[in] task_parameter_distribution The distribution from which to sample task parameters
+   * \param[in] n_demos The number of demos
+   * \param[in] ts The times at which to sample the trajectory
+   * \param[out] demonstrations The demonstrations (a vector of trajectories)
+   */
+  void generateDemonstrations(DistributionGaussian* task_parameter_distribution, int n_demos, const Eigen::VectorXd& ts, std::vector<Trajectory>& demonstrations) const
+  {
+    Eigen::MatrixXd task_parameters;
+    
+    demonstrations = std::vector<Trajectory>(n_demos);
+    for (int i_demo=0; i_demo<n_demos; i_demo++)
+    {
+      task_parameter_distribution->generateSamples(n_demos,task_parameters);
+      generateDemonstration(task_parameters, ts, demonstrations[i_demo]); 
+    }
+    
+  }
+
+  /*
+  Matlab code:
+  void generatedemonstrationsrandom(int n_demonstrations, Matrix&task_instances)
+  {
+     // Generate random task parameters
+     task_parameters = obj.task_parameters_distribution.getsamples(n_demonstrations);
+     // Generate task instances
+     generatedemonstrations(task_parameters,task_instances);
+  }
+    
+    function task_instances = generatedemonstrationsgrid(obj,n_demonstrations)
+      n_dim = obj.task_parameters_distribution.n_dims;
+
+      % Process arguments
+      if (length(n_demonstrations)==1)
+         % Copy value to make array of length n_dim
+        n_demonstrations = n_demonstrations*ones(1,n_dim);
+      elseif (length(n_demonstrations)==n_dim)
+        % Everything is fine
+      else
+        error('n_demonstrations should be of length 1 or n_dim') %#ok<WNTAG>
+      end
+
+      % Generate task parameters on a grid
+      task_parameters = obj.task_parameters_distribution.getgridsamples(n_demonstrations);
+      
+      % Remove duplicate rows (might be due to redundant dimensions)
+      task_parameters = unique(task_parameters,'rows');
+
+      % Generate task instances
+      task_instances = obj.generatedemonstrations(task_parameters);
+   
+    end
+  end
+  */
+  
+private:
+  /** Give boost serialization access to private members. */  
+  friend class boost::serialization::access;
+  
+  /** Serialize class data members to boost archive. 
+   * \param[in] ar Boost archive
+   * \param[in] version Version of the class
+   * See http://www.boost.org/doc/libs/1_55_0/libs/serialization/doc/tutorial.html#simplecase
+   */
+  template<class Archive>
+  void serialize(Archive & ar, const unsigned int version)
+  {
+    // serialize base class information
+    ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Task);
+  }
+  
+};
+  
+} // namespace DmpBbo
+
+#include <boost/serialization/assume_abstract.hpp>
+/** Don't add version information to archives. */
+BOOST_SERIALIZATION_ASSUME_ABSTRACT(DmpBbo::TaskWithTrajectoryDemonstrator);
+ 
+#include <boost/serialization/export.hpp>
+/** Don't add version information to archives. */
+BOOST_CLASS_IMPLEMENTATION(DmpBbo::TaskWithTrajectoryDemonstrator,boost::serialization::object_serializable);
+
+#endif
+

--- a/src/dmp_bbo/UpdateSummaryParallel.cpp
+++ b/src/dmp_bbo/UpdateSummaryParallel.cpp
@@ -20,7 +20,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
  */
-
+#define EIGEN2_SUPPORT
 #include "dmp_bbo/UpdateSummaryParallel.hpp"
 
 #include "bbo/DistributionGaussian.hpp"
@@ -69,7 +69,7 @@ bool saveToDirectory(const UpdateSummaryParallel& summary, string directory, boo
   int n_parallel = summary.distributions.size();
   VectorXi n_parallel_vec = VectorXi::Constant(1,n_parallel);
   saveMatrix(directory,"n_parallel.txt",n_parallel_vec,overwrite);
-
+/*
   for (int ii=0; ii<n_parallel; ii++)
   {
     stringstream stream;
@@ -86,7 +86,7 @@ bool saveToDirectory(const UpdateSummaryParallel& summary, string directory, boo
     if (!saveMatrix(dir, "distribution_new_covar"+suf, summary.distributions_new[ii]->covar(), ow))
       return false;
   }
-
+*/
   return true;
 
 }

--- a/src/dmp_bbo/UpdateSummaryParallel.cpp
+++ b/src/dmp_bbo/UpdateSummaryParallel.cpp
@@ -3,20 +3,20 @@
  * @brief  UpdateSummaryParallel class header file.
  * @author Freek Stulp
  *
- * This file is part of DmpBbo, a set of libraries and programs for the 
+ * This file is part of DmpBbo, a set of libraries and programs for the
  * black-box optimization of dynamical movement primitives.
  * Copyright (C) 2014 Freek Stulp, ENSTA-ParisTech
- * 
+ *
  * DmpBbo is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 2 of the License, or
  * (at your option) any later version.
- * 
+ *
  * DmpBbo is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -31,7 +31,7 @@
 #include <fstream>
 #include <boost/filesystem.hpp>
 #include <eigen3/Eigen/Core>
-#include <eigen3/Eigen/Eigenvalues> 
+#include <eigen3/Eigen/Eigenvalues>
 
 using namespace std;
 using namespace Eigen;
@@ -57,7 +57,7 @@ bool saveToDirectory(const UpdateSummaryParallel& summary, string directory, boo
   bool ow = overwrite;
   string dir = directory;
   VectorXd cost_eval_vec = VectorXd::Constant(1,summary.cost_eval);
-  
+
   if (!saveMatrix(dir, "cost_eval.txt",          cost_eval_vec,                 ow)) return false;
   if (!saveMatrix(dir, "costs.txt",              summary.costs,                 ow)) return false;
   if (!saveMatrix(dir, "weights.txt",            summary.weights,               ow)) return false;
@@ -69,7 +69,7 @@ bool saveToDirectory(const UpdateSummaryParallel& summary, string directory, boo
   int n_parallel = summary.distributions.size();
   VectorXi n_parallel_vec = VectorXi::Constant(1,n_parallel);
   saveMatrix(directory,"n_parallel.txt",n_parallel_vec,overwrite);
-  
+
   for (int ii=0; ii<n_parallel; ii++)
   {
     stringstream stream;
@@ -77,31 +77,51 @@ bool saveToDirectory(const UpdateSummaryParallel& summary, string directory, boo
     string suf = stream.str();
     if (!saveMatrix(dir, "distribution_mean"+suf,  summary.distributions[ii]->mean(),  ow))
       return false;
-    if (!saveMatrix(dir, "distribution_covar"+suf, summary.distributions[ii]->covar(), ow)) 
+    if (!saveMatrix(dir, "distribution_covar"+suf, summary.distributions[ii]->covar(), ow))
       return false;
-    if (!saveMatrix(dir, "samples"+suf,            summary.samples[ii],               ow)) 
+    if (!saveMatrix(dir, "samples"+suf,            summary.samples[ii],               ow))
       return false;
-    if (!saveMatrix(dir, "distribution_new_mean"+suf,  summary.distributions_new[ii]->mean(),  ow)) 
+    if (!saveMatrix(dir, "distribution_new_mean"+suf,  summary.distributions_new[ii]->mean(),  ow))
       return false;
-    if (!saveMatrix(dir, "distribution_new_covar"+suf, summary.distributions_new[ii]->covar(), ow)) 
+    if (!saveMatrix(dir, "distribution_new_covar"+suf, summary.distributions_new[ii]->covar(), ow))
       return false;
-  }  
-  
+  }
+
   return true;
-  
+
 }
 
-bool saveToDirectory(const vector<UpdateSummaryParallel>& update_summaries, std::string directory, bool overwrite, bool only_learning_curve)
+bool saveToDirectory(const vector<UpdateSummaryParallel>& update_summaries, std::string directory, bool overwrite, bool only_learning_curve, bool stack_updates)
 {
-  
+  int dir_buffer = 1;
+  if ((stack_updates) && (overwrite))//ensuring overwrite will continue to update the learning curve file
+  {
+    if (boost::filesystem::exists(directory))
+    {
+      int MAX_UPDATE = 99999; // Cannot store more in %05d format
+      int old_update=1;
+      while ((old_update<MAX_UPDATE) && (dir_buffer==1))
+      {
+        stringstream stream;
+        stream << directory << "/update" << setw(5) << setfill('0') << old_update << "/";
+        string directory_update = stream.str();
+        if (!boost::filesystem::exists(directory_update))
+        {
+          // Found a directory that doesn't exist yet!
+          dir_buffer = old_update;
+        }
+        old_update++;
+      }
+    }
+  }
   // Save the learning curve
-  int n_updates = update_summaries.size();  
+  int n_updates = update_summaries.size();
   assert(n_updates>0);
-  
+
   int n_parallel = update_summaries[0].distributions.size();
   MatrixXd learning_curve(n_updates,2+n_parallel);
   learning_curve(0,0) = 0; // First evaluation is at 0
-  
+
   for (int i_update=0; i_update<n_updates; i_update++)
   {
 
@@ -109,12 +129,12 @@ bool saveToDirectory(const vector<UpdateSummaryParallel>& update_summaries, std:
     if (i_update>0)
     {
       int n_samples = update_summaries[i_update].costs.rows();
-      learning_curve(i_update,0) = learning_curve(i_update-1,0) + n_samples; 
+      learning_curve(i_update,0) = learning_curve(i_update-1,0) + n_samples;
     }
-    
+
     // The cost of the evaluation at this update
     learning_curve(i_update,1) = update_summaries[i_update].cost_eval;
-    
+
     for (int i_parallel=0; i_parallel<n_parallel; i_parallel++)
     {
       // The largest eigenvalue of the covariance matrix, for each distribution
@@ -122,19 +142,19 @@ bool saveToDirectory(const vector<UpdateSummaryParallel>& update_summaries, std:
       MatrixXd eigen_values = distribution->covar().eigenvalues().real();
       learning_curve(i_update,2+i_parallel) = sqrt(eigen_values.maxCoeff());
     }
-    
+
   }
 
   if (!saveMatrix(directory, "learning_curve.txt", learning_curve, overwrite))
     return false;
-    
+
   if (!only_learning_curve)
   {
     // Save all the information in the update summaries
     for (int i_update=0; i_update<n_updates; i_update++)
     {
       stringstream stream;
-      stream << directory << "/update" << setw(5) << setfill('0') << i_update+1 << "/";
+      stream << directory << "/update" << setw(5) << setfill('0') << i_update+dir_buffer << "/";
       if (!saveToDirectory(update_summaries[i_update], stream.str(),overwrite))
         return false;
     }
@@ -142,45 +162,5 @@ bool saveToDirectory(const vector<UpdateSummaryParallel>& update_summaries, std:
   return true;
 }
 
-
-bool saveToDirectoryNewUpdate(const UpdateSummaryParallel& update_summary, std::string directory)
-{
-
-  // Make directory if it doesn't already exist
-  if (!boost::filesystem::exists(directory))
-  {
-    if (!boost::filesystem::create_directories(directory))
-    {
-      cerr << __FILE__ << ":" << __LINE__ << ":";
-      cerr << "Couldn't make directory file '" << directory << "'." << endl;
-      return false;
-    }
-    // Directory didn't exist yet, so this must be the first update.
-    directory += "/update00001/";
-    bool overwrite=true;
-    return saveToDirectory(update_summary,directory,overwrite);
-  }
-  
-  // Find the directory with the highest update
-  // todo: this can probably be done more efficiently with boost::filesystem somehow
-  int MAX_UPDATE = 99999; // Cannot store more in %05d format
-  int i_update=1;
-  while (i_update<MAX_UPDATE)
-  {
-    stringstream stream;
-    stream << directory << "/update" << setw(5) << setfill('0') << i_update << "/";
-    string directory_update = stream.str();
-    if (!boost::filesystem::exists(directory_update))
-    {
-      // Found a directory that doesn't exist yet!
-      bool overwrite=true;
-      return saveToDirectory(update_summary,directory_update,overwrite);
-    }
-    i_update++;
-  }
-  
-  std::cerr << "Sorry, directory " << directory << " is already full with update subdirectories." << std::endl;
-  return false;
-}
 
 }

--- a/src/dmp_bbo/UpdateSummaryParallel.cpp~
+++ b/src/dmp_bbo/UpdateSummaryParallel.cpp~
@@ -1,0 +1,166 @@
+/**
+ * @file   UpdateSummaryParallel.hpp
+ * @brief  UpdateSummaryParallel class header file.
+ * @author Freek Stulp
+ *
+ * This file is part of DmpBbo, a set of libraries and programs for the
+ * black-box optimization of dynamical movement primitives.
+ * Copyright (C) 2014 Freek Stulp, ENSTA-ParisTech
+ *
+ * DmpBbo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * DmpBbo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "dmp_bbo/UpdateSummaryParallel.hpp"
+
+#include "bbo/DistributionGaussian.hpp"
+#include "dmpbbo_io/EigenFileIO.hpp"
+
+#include <iostream>
+#include <iomanip>
+#include <fstream>
+#include <boost/filesystem.hpp>
+#include <eigen3/Eigen/Core>
+#include <eigen3/Eigen/Eigenvalues>
+
+using namespace std;
+using namespace Eigen;
+
+namespace DmpBbo {
+
+
+bool saveToDirectory(const UpdateSummaryParallel& summary, string directory, bool overwrite)
+{
+
+  // Make directory if it doesn't already exist
+  if (!boost::filesystem::exists(directory))
+  {
+    if (!boost::filesystem::create_directories(directory))
+    {
+      cerr << __FILE__ << ":" << __LINE__ << ":";
+      cerr << "Couldn't make directory file '" << directory << "'." << endl;
+      return false;
+    }
+  }
+
+  // Abbreviations to make it fit on one line
+  bool ow = overwrite;
+  string dir = directory;
+  VectorXd cost_eval_vec = VectorXd::Constant(1,summary.cost_eval);
+
+  if (!saveMatrix(dir, "cost_eval.txt",          cost_eval_vec,                 ow)) return false;
+  if (!saveMatrix(dir, "costs.txt",              summary.costs,                 ow)) return false;
+  if (!saveMatrix(dir, "weights.txt",            summary.weights,               ow)) return false;
+  if (summary.cost_vars_eval.size()>0)
+    if (!saveMatrix(dir, "cost_vars_eval.txt",summary.cost_vars_eval, ow)) return false;
+  if (summary.cost_vars.size()>0)
+    if (!saveMatrix(dir, "cost_vars.txt",summary.cost_vars, ow)) return false;
+
+  int n_parallel = summary.distributions.size();
+  VectorXi n_parallel_vec = VectorXi::Constant(1,n_parallel);
+  saveMatrix(directory,"n_parallel.txt",n_parallel_vec,overwrite);
+/*
+  for (int ii=0; ii<n_parallel; ii++)
+  {
+    stringstream stream;
+    stream << "_" << setw(2) << setfill('0') << ii << ".txt";
+    string suf = stream.str();
+    if (!saveMatrix(dir, "distribution_mean"+suf,  summary.distributions[ii]->mean(),  ow))
+      return false;
+    if (!saveMatrix(dir, "distribution_covar"+suf, summary.distributions[ii]->covar(), ow))
+      return false;
+    if (!saveMatrix(dir, "samples"+suf,            summary.samples[ii],               ow))
+      return false;
+    if (!saveMatrix(dir, "distribution_new_mean"+suf,  summary.distributions_new[ii]->mean(),  ow))
+      return false;
+    if (!saveMatrix(dir, "distribution_new_covar"+suf, summary.distributions_new[ii]->covar(), ow))
+      return false;
+  }
+*/
+  return true;
+
+}
+
+bool saveToDirectory(const vector<UpdateSummaryParallel>& update_summaries, std::string directory, bool overwrite, bool only_learning_curve, bool stack_updates)
+{
+  int dir_buffer = 1;
+  if ((stack_updates) && (overwrite))//ensuring overwrite will continue to update the learning curve file
+  {
+    if (boost::filesystem::exists(directory))
+    {
+      int MAX_UPDATE = 99999; // Cannot store more in %05d format
+      int old_update=1;
+      while ((old_update<MAX_UPDATE) && (dir_buffer==1))
+      {
+        stringstream stream;
+        stream << directory << "/update" << setw(5) << setfill('0') << old_update << "/";
+        string directory_update = stream.str();
+        if (!boost::filesystem::exists(directory_update))
+        {
+          // Found a directory that doesn't exist yet!
+          dir_buffer = old_update;
+        }
+        old_update++;
+      }
+    }
+  }
+  // Save the learning curve
+  int n_updates = update_summaries.size();
+  assert(n_updates>0);
+
+  int n_parallel = update_summaries[0].distributions.size();
+  MatrixXd learning_curve(n_updates,2+n_parallel);
+  learning_curve(0,0) = 0; // First evaluation is at 0
+
+  for (int i_update=0; i_update<n_updates; i_update++)
+  {
+
+    // Number of samples at which an evaluation was performed.
+    if (i_update>0)
+    {
+      int n_samples = update_summaries[i_update].costs.rows();
+      learning_curve(i_update,0) = learning_curve(i_update-1,0) + n_samples;
+    }
+
+    // The cost of the evaluation at this update
+    learning_curve(i_update,1) = update_summaries[i_update].cost_eval;
+
+    for (int i_parallel=0; i_parallel<n_parallel; i_parallel++)
+    {
+      // The largest eigenvalue of the covariance matrix, for each distribution
+      DistributionGaussian* distribution = update_summaries[i_update].distributions[i_parallel];
+      MatrixXd eigen_values = distribution->covar().eigenvalues().real();
+      learning_curve(i_update,2+i_parallel) = sqrt(eigen_values.maxCoeff());
+    }
+
+  }
+
+  if (!saveMatrix(directory, "learning_curve.txt", learning_curve, overwrite))
+    return false;
+
+  if (!only_learning_curve)
+  {
+    // Save all the information in the update summaries
+    for (int i_update=0; i_update<n_updates; i_update++)
+    {
+      stringstream stream;
+      stream << directory << "/update" << setw(5) << setfill('0') << i_update+dir_buffer << "/";
+      if (!saveToDirectory(update_summaries[i_update], stream.str(),overwrite))
+        return false;
+    }
+  }
+  return true;
+}
+
+
+}

--- a/src/dmp_bbo/UpdateSummaryParallel.hpp
+++ b/src/dmp_bbo/UpdateSummaryParallel.hpp
@@ -23,7 +23,7 @@
 
 #ifndef UPDATESUMMARYPARALLEL_H
 #define UPDATESUMMARYPARALLEL_H
-
+#define EIGEN2_SUPPORT
 #include <string>
 #include <vector>
 #include <eigen3/Eigen/Core>

--- a/src/dmp_bbo/UpdateSummaryParallel.hpp
+++ b/src/dmp_bbo/UpdateSummaryParallel.hpp
@@ -3,26 +3,26 @@
  * @brief  UpdateSummaryParallel class header file.
  * @author Freek Stulp
  *
- * This file is part of DmpBbo, a set of libraries and programs for the 
+ * This file is part of DmpBbo, a set of libraries and programs for the
  * black-box optimization of dynamical movement primitives.
  * Copyright (C) 2014 Freek Stulp, ENSTA-ParisTech
- * 
+ *
  * DmpBbo is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 2 of the License, or
  * (at your option) any later version.
- * 
+ *
  * DmpBbo is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 #ifndef UPDATESUMMARYPARALLEL_H
-#define UPDATESUMMARYPARALLEL_H   
+#define UPDATESUMMARYPARALLEL_H
 
 #include <string>
 #include <vector>
@@ -31,12 +31,12 @@
 #include <boost/serialization/nvp.hpp>
 
 namespace DmpBbo {
-  
+
 // Forward declaration
 class DistributionGaussian;
 
 // POD class, http://en.wikipedia.org/wiki/Plain_old_data_structure
-/** POD class for storing the information relevant to a distribution update. 
+/** POD class for storing the information relevant to a distribution update.
  * Used for logging purposes.
  * This is a "plain old data" class, i.e. all member variables are public
  */
@@ -54,13 +54,13 @@ public:
   Eigen::MatrixXd weights;
   /** Distribution after the update. */
   std::vector<DistributionGaussian*> distributions_new;
-  
+
   /** The cost-relevant variables. Only used when Task/TaskSolver approach is used.  */
   Eigen::MatrixXd cost_vars;
-  /** The cost-relevant variables for the evaluation. 
+  /** The cost-relevant variables for the evaluation.
       Only used when Task/TaskSolver approach is used.  */
   Eigen::MatrixXd cost_vars_eval;
-  
+
 };
 
 /**
@@ -81,18 +81,7 @@ bool saveToDirectory(const UpdateSummaryParallel& update_summary, std::string di
  * \param[in] only_learning_curve Save only the learning curve (default: false)
  * \return true if saving the summary was successful, false otherwise
  */
-bool saveToDirectory(const std::vector<UpdateSummaryParallel>& update_summaries, std::string directory, bool overwrite=false, bool only_learning_curve=false);
-
-/**
- * Save an update summary to a directory.
- * This version searches directory for subdirectories updateN and writes the data into a new 
- * directory updateN+1 (the actual format is update%05d). E.g. if there are directories:
- * update00000, update00001, and update00002, this function will write to update00003
- * \param[in] update_summary Object to write
- * \param[in] directory Directory to which to write object
- * \return true if saving the UpdateSummary was successful, false otherwise
- */
-bool saveToDirectoryNewUpdate(const UpdateSummaryParallel& update_summary, std::string directory);
+bool saveToDirectory(const std::vector<UpdateSummaryParallel>& update_summaries, std::string directory, bool overwrite=false, bool only_learning_curve=false, bool stack_updates=false);
 
 }
 
@@ -101,7 +90,7 @@ bool saveToDirectoryNewUpdate(const UpdateSummaryParallel& update_summary, std::
 namespace boost {
 namespace serialization {
 
-/** Serialize class data members to boost archive. 
+/** Serialize class data members to boost archive.
  * \param[in] ar Boost archive
  * \param[in] update_summary UpdateSummaryParallel object to serialize.
  * \param[in] version Version of the class

--- a/src/dmp_bbo/UpdateSummaryParallel.hpp~
+++ b/src/dmp_bbo/UpdateSummaryParallel.hpp~
@@ -1,0 +1,120 @@
+/**
+ * @file   UpdateSummaryParallel.hpp
+ * @brief  UpdateSummaryParallel class header file.
+ * @author Freek Stulp
+ *
+ * This file is part of DmpBbo, a set of libraries and programs for the
+ * black-box optimization of dynamical movement primitives.
+ * Copyright (C) 2014 Freek Stulp, ENSTA-ParisTech
+ *
+ * DmpBbo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * DmpBbo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef UPDATESUMMARYPARALLEL_H
+#define UPDATESUMMARYPARALLEL_H
+
+#include <string>
+#include <vector>
+#include <eigen3/Eigen/Core>
+
+#include <boost/serialization/nvp.hpp>
+
+namespace DmpBbo {
+
+// Forward declaration
+class DistributionGaussian;
+
+// POD class, http://en.wikipedia.org/wiki/Plain_old_data_structure
+/** POD class for storing the information relevant to a distribution update.
+ * Used for logging purposes.
+ * This is a "plain old data" class, i.e. all member variables are public
+ */
+class UpdateSummaryParallel {
+public:
+  /** Distribution before update. */
+  std::vector<DistributionGaussian*> distributions;
+  /** Samples in the epoch. */
+  std::vector<Eigen::MatrixXd> samples;
+  /** Cost of the evaluation sample */
+  double cost_eval;
+  /** Costs of the samples in the epoch. */
+  Eigen::VectorXd costs;
+  /** Weights of the samples in the epoch, computed from their costs. */
+  Eigen::MatrixXd weights;
+  /** Distribution after the update. */
+  std::vector<DistributionGaussian*> distributions_new;
+
+  /** The cost-relevant variables. Only used when Task/TaskSolver approach is used.  */
+  Eigen::MatrixXd cost_vars;
+  /** The cost-relevant variables for the evaluation.
+      Only used when Task/TaskSolver approach is used.  */
+  Eigen::MatrixXd cost_vars_eval;
+
+};
+
+/**
+ * Save an update summary to a directory
+ * \param[in] update_summary Object to write
+ * \param[in] directory Directory to which to write object
+ * \param[in] overwrite Overwrite existing files in the directory above (default: false)
+ * \return true if saving the summary was successful, false otherwise
+ */
+bool saveToDirectory(const UpdateSummaryParallel& update_summary, std::string directory, bool overwrite=false);
+
+
+/**
+ * Save a vector of update summaries to a directory
+ * \param[in] update_summary Object to write
+ * \param[in] directory Directory to which to write object
+ * \param[in] overwrite Overwrite existing files in the directory above (default: false)
+ * \param[in] only_learning_curve Save only the learning curve (default: false)
+ * \return true if saving the summary was successful, false otherwise
+ */
+bool saveToDirectory(const std::vector<UpdateSummaryParallel>& update_summaries, std::string directory, bool overwrite=false, bool only_learning_curve=false, bool stack_updates=false);
+
+}
+
+
+/** Serialization function for boost::serialization. */
+namespace boost {
+namespace serialization {
+
+/** Serialize class data members to boost archive.
+ * \param[in] ar Boost archive
+ * \param[in] update_summary UpdateSummaryParallel object to serialize.
+ * \param[in] version Version of the class
+ * See http://www.boost.org/doc/libs/1_55_0/libs/serialization/doc/tutorial.html#simplecase
+ */
+template<class Archive>
+void serialize(Archive & ar, DmpBbo::UpdateSummaryParallel& update_summary, const unsigned int version)
+{
+  ar & BOOST_SERIALIZATION_NVP(update_summary.distributions);
+  ar & BOOST_SERIALIZATION_NVP(update_summary.samples);
+  ar & BOOST_SERIALIZATION_NVP(update_summary.cost_eval);
+  ar & BOOST_SERIALIZATION_NVP(update_summary.costs);
+  ar & BOOST_SERIALIZATION_NVP(update_summary.weights);
+  ar & BOOST_SERIALIZATION_NVP(update_summary.distributions_new);
+  ar & BOOST_SERIALIZATION_NVP(update_summary.cost_vars);
+  ar & BOOST_SERIALIZATION_NVP(update_summary.cost_vars_eval);
+}
+
+} // namespace serialization
+} // namespace boost
+
+
+/** Don't add version information to archives. */
+BOOST_CLASS_IMPLEMENTATION(DmpBbo::UpdateSummaryParallel,boost::serialization::object_serializable);
+
+#endif
+

--- a/src/dmp_bbo/runEvolutionaryOptimizationParallel.cpp
+++ b/src/dmp_bbo/runEvolutionaryOptimizationParallel.cpp
@@ -20,7 +20,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
  */
-
+#define EIGEN2_SUPPORT
 #include "dmp_bbo/runEvolutionaryOptimizationParallel.hpp"
 
 #include "bbo/Task.hpp"

--- a/src/dmp_bbo/runEvolutionaryOptimizationParallel.cpp~
+++ b/src/dmp_bbo/runEvolutionaryOptimizationParallel.cpp~
@@ -1,0 +1,128 @@
+/**
+ * @file runEvolutionaryOptimizationParallel.cpp
+ * @brief  Source file for function to run multiple evolutionary optimization processes in parallel.
+ * @author Freek Stulp
+ *
+ * This file is part of DmpBbo, a set of libraries and programs for the 
+ * black-box optimization of dynamical movement primitives.
+ * Copyright (C) 2014 Freek Stulp, ENSTA-ParisTech
+ * 
+ * DmpBbo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ * 
+ * DmpBbo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "dmp_bbo/runEvolutionaryOptimizationParallel.hpp"
+
+#include "bbo/Task.hpp"
+#include "bbo/DistributionGaussian.hpp"
+#include "bbo/Updater.hpp"
+#include "dmp_bbo/TaskSolverParallel.hpp"
+#include "dmp_bbo/UpdateSummaryParallel.hpp"
+#include "dmpbbo_io/EigenFileIO.hpp"
+
+#include <iomanip>
+#include <fstream>
+#include <boost/filesystem.hpp>
+#include <eigen3/Eigen/Core>
+
+using namespace std;
+using namespace Eigen;
+
+namespace DmpBbo {
+
+bool saveTask(string save_directory, Task* task, TaskSolver* task_solver, bool overwrite=false);
+
+bool saveUpdate(string save_directory, int i_update, const vector<UpdateSummary>& update_summaries, const MatrixXd& cost_vars, const MatrixXd& cost_vars_eval, bool overwrite=false);
+
+void runEvolutionaryOptimizationParallel(Task* task, TaskSolverParallel* task_solver, vector<DistributionGaussian*> distributions, Updater* updater, int n_updates, int n_samples_per_update, string save_directory, bool overwrite, bool only_learning_curve)
+{  
+  // Some variables
+  int n_parallel = distributions.size();
+  vector<MatrixXd> sample_eval(n_parallel);
+  vector<MatrixXd> samples(n_parallel);
+  MatrixXd cost_vars, cost_vars_eval;
+  VectorXd costs, cost_eval;
+  // Bookkeeping
+  // This is where the UpdateSummary objects are stored, one for each parallel optimization
+  vector<UpdateSummary> cur_summaries(n_parallel);
+  // This is the UpdateSummaryParallel, that merges the above
+  UpdateSummaryParallel update_summary;
+  update_summary.distributions.resize(n_parallel); // Pre-allocate enough space here
+  update_summary.distributions_new.resize(n_parallel); // Pre-allocate enough space here
+  update_summary.samples.resize(n_parallel); // Pre-allocate enough space here
+  // This is where the UpdateSummaryParallel objects are accumulated, one for each update
+  vector<UpdateSummaryParallel> update_summaries;
+  
+  // Optimization loop
+  for (int i_update=0; i_update<n_updates; i_update++)
+  {
+    // 0. Get cost of current distribution mean
+    for (int pp=0; pp<n_parallel; pp++)
+      sample_eval[pp] = distributions[pp]->mean().transpose();
+    task_solver->performRollouts(sample_eval,cost_vars_eval);
+    task->evaluate(cost_vars_eval,cost_eval);
+    
+    // 1. Sample from distribution
+    for (int pp=0; pp<n_parallel; pp++)
+      distributions[pp]->generateSamples(n_samples_per_update, samples[pp]);
+
+    // 2. Perform rollouts for the samples
+    task_solver->performRollouts(samples, cost_vars);
+      
+    // 3. Evaluate the last batch of rollouts
+    task->evaluate(cost_vars,costs);
+  
+    // 4. Update parameters
+    for (int pp=0; pp<n_parallel; pp++)
+      updater->updateDistribution(*(distributions[pp]), samples[pp], costs, *(distributions[pp]),
+                                                                      (cur_summaries[pp]));
+      
+    // Some output and/or saving to file (if "directory" is set)
+    if (save_directory.empty()) 
+    {
+      cout << i_update+1 << "  cost_eval=" << cost_eval << "  ";
+      if (distributions.size()==1)
+        cout << *(distributions[0]);
+      else
+        for (unsigned int ii=0; ii<distributions.size(); ii++)
+          cout  << endl << "       distributions["<<ii<<"]=" << *(distributions[ii]);
+      cout << endl;
+    }
+    else
+    {
+      update_summary.cost_eval = cost_eval[0];
+      update_summary.cost_vars_eval = cost_vars_eval;
+      update_summary.cost_vars = cost_vars;
+      update_summary.costs =  costs;
+      for (int pp=0; pp<n_parallel; pp++)
+      {
+        update_summary.distributions[pp] =  cur_summaries[pp].distribution;
+        update_summary.distributions_new[pp] =  cur_summaries[pp].distribution_new;
+        update_summary.samples[pp] =  cur_summaries[pp].samples;
+      }
+      update_summaries.push_back(update_summary);
+    }
+  }
+
+  // Save update summaries to file, if necessary
+  if (!save_directory.empty())
+  {
+    saveToDirectory(update_summaries,save_directory,overwrite,only_learning_curve);
+    // If you store only the learning curve, no need to save the script to visualize rollouts    
+    if (!only_learning_curve)
+      task->savePerformRolloutsPlotScript(save_directory);
+  }
+  
+}
+
+}

--- a/src/dmpbbo_io/EigenBoostSerialization.hpp
+++ b/src/dmpbbo_io/EigenBoostSerialization.hpp
@@ -25,7 +25,7 @@
 
 #ifndef EIGENBOOSTSERIALIZATION_HPP
 #define EIGENBOOSTSERIALIZATION_HPP
-
+#define EIGEN2_SUPPORT
 #include <eigen3/Eigen/Core>
 
 #include <boost/serialization/split_free.hpp>

--- a/src/dmpbbo_io/EigenBoostSerialization.hpp~
+++ b/src/dmpbbo_io/EigenBoostSerialization.hpp~
@@ -1,0 +1,162 @@
+/**
+ * @file EigenBoostSerialization.hpp
+ * @brief  Header file for serialization of Eigen matrices.
+ * @author Freek Stulp
+ *
+ * Implementations are in the tpp file
+ *
+ * This file is part of DmpBbo, a set of libraries and programs for the 
+ * black-box optimization of dynamical movement primitives.
+ * Copyright (C) 2014 Freek Stulp, ENSTA-ParisTech
+ * 
+ * DmpBbo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ * 
+ * DmpBbo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef EIGENBOOSTSERIALIZATION_HPP
+#define EIGENBOOSTSERIALIZATION_HPP
+//#define EIGEN2_SUPPORT
+#include <eigen3/Eigen/Core>
+
+#include <boost/serialization/split_free.hpp>
+#include <boost/serialization/level.hpp>
+
+namespace Eigen {
+/** Convert an Eigen matrix to a string. */
+template<typename _Scalar, int _Rows, int _Cols, int _Options, int _MaxRows, int _MaxCols>
+std::string toString(const Eigen::Matrix<_Scalar, _Rows, _Cols, _Options, _MaxRows, _MaxCols> & matrix);
+}  // namespace Eigen
+
+namespace boost { 
+namespace serialization {
+  
+/** Serialize an Eigen matrix. */
+template<class Archive, typename _Scalar, int _Rows, int _Cols, int _Options, int _MaxRows, int _MaxCols>
+inline void save(
+    Archive & ar, 
+    const Eigen::Matrix<_Scalar, _Rows, _Cols, _Options, _MaxRows, _MaxCols> & matrix, 
+    const unsigned int file_version
+);
+
+/** Deserialize an Eigen matrix. */
+template<class Archive, typename _Scalar, int _Rows, int _Cols, int _Options, int _MaxRows, int _MaxCols>
+inline void load(
+    Archive & ar, 
+    Eigen::Matrix<_Scalar, _Rows, _Cols, _Options, _MaxRows, _MaxCols> & matrix, 
+    const unsigned int file_version
+);
+
+/** Serialize an Eigen matrix. */
+template<class Archive, typename _Scalar, int _Rows, int _Cols, int _Options, int _MaxRows, int _MaxCols>
+inline void serialize(
+    Archive & ar,
+    Eigen::Matrix<_Scalar, _Rows, _Cols, _Options, _MaxRows, _MaxCols> & t, 
+    const unsigned int file_version
+){
+    split_free(ar, t, file_version); 
+}
+
+
+} // namespace serialization
+} // namespace boost
+
+// The next structure is not so relevant for the documentation, and has a very long name. So we 
+// exclude it from the documentation with doxygen's "cond"
+/// \cond HIDDEN_SYMBOLS
+
+namespace boost {
+  namespace serialization {
+    template <typename _Scalar, int _Rows, int _Cols, int _Options, int _MaxRows, int _MaxCols>
+    /** Implementation level for Eigen matrices.
+     * Basically, this tells boost:serialization not to include version information in the output.
+     * See also: http://www.boost.org/doc/libs/1_35_0/libs/serialization/doc/traits.html#level
+     * This whole thing is needed because BOOST_CLASS_IMPLEMENTATION doesn't work for templated
+     * clasess (such as the Eigen Matrix)
+     */
+    struct implementation_level<Eigen::Matrix<_Scalar, _Rows, _Cols, _Options, _MaxRows, _MaxCols> > 
+    {
+      /** Typedef for tag */
+      typedef mpl::integral_c_tag tag;
+      /** Typedef for tag */
+      typedef mpl::int_< boost::serialization::object_serializable > type;
+      /** Set implementation_level type */
+      static const int value = implementation_level::type::value;
+    };
+  }
+}
+/// \endcond
+
+#include "EigenBoostSerialization.tpp"
+
+/**
+ * \page page_serialization Serialization
+ 
+Serialization and deserialization of objects serves two purposes in this code: 
+
+\li Reading parameter/experiment settings from a file. For instance, you could specify the MetaParameters of a FunctionApproximator in a file, read that file in your program, and train a FunctionApproximator with those MetaParameters. To try different MetaParameters settings you only have to change the input file, without having to recompile.
+To be able to edit such parameter files, the files should be human readable. Ideally, it should be JSON, because it is very readable and compact.
+
+\li Saving the results of an experiment. Saving such results to binary files would be more compact, but to ensure that the same format is used for both serialization and deserialization, we use a human-readable format here also.
+
+
+I considered the following options.
+
+\li Boost property tree: it makes a mess of arrays when saving to JSON
+
+\li Google protobuf: I preferred to not have code generated for me
+
+\li cereal: http://uscilab.github.io/cereal/, external library. Really the best option, but I tried to avoid users having to use non-standard libraries.
+
+\li jsoncpp: Not ideal for serialization, more for read/write of JSON.
+
+In summary, I could not find any libraries that were easy to install and could serialize to/from JSON. Therefore, I went for the second choice, which was XML. Because boost is a standard, and compiles on most platforms, I decided to use boost:: serialization. I consider this to be quite a compromise, because I find boost::serialization quite messy, it is not well documented, and it took me quite a while to get it working properly (especially the registering of derived classes, for which you have to use a wierd combination of macros in the exact right places)
+
+Since I was writing to XML with boost::serialization anyway, many classes implement a toString() method that simply returns the XML code (without a header) that results from serialization. 
+The RETURN_STRING_FROM_BOOST_SERIALIZATION_XML macro does all the work for writing to an XML archive and converting it to a string. Having XML as output is not ideal, but it avoid lots of duplicate code. Perhaps boost::serialization will one day be able to write to JSON also, and then this could be used instead. 
+
+I decided to go for string toString(void) instead of ostream& toStream(ostream&), because toString allows you to easily use both the output stream operator  (output << obj.toString()) and printf (printf("%s",obj.toString()), whereas toStream would be much more messy to use in combination with printf (not everyone likes to use the outputstream operator). 
+
+\section sec_boost_serialization_ugliness Boost serialization issues
+
+With boost::serialization, it is possible to serialize classes without a default constuctor with 
+http://www.boost.org/doc/libs/1_55_0/libs/serialization/doc/serialization.html#constructors
+But load_construct_data requires the creation of an object, which we cannot when classes are abstract. It seems no-one knows how to solve this:
+\li http://lists.boost.org/boost-users/2005/09/13827.php
+\li http://boost.2283326.n4.nabble.com/serialization-Serializing-classes-with-no-default-constructors-td2557921.html
+
+For this reason abstract base classes that are to be serialized with boost must have a default constructor, and may not have const members. This is really a pain, because a serialization library should not enforce such design decisions... But this is the way it is in the code.
+
+\section sec_eigen_boost_serialization Serializing boost matrices
+
+To avoid bloating the serialization of Eigen matrices with lots of XML tags, they are serialized in a special way. The following examples show how Eigen matrices are serialized in XML:
+
+\li Standard matrix:
+\code
+<m>2X3; 0 0 0; 1 1 1</m>
+\endcode
+
+\li Vector:
+\code
+<m>3X1; 0 0 0</m>
+<m>1X3; 0 0 0</m>
+\endcode
+
+\li Diagonal matrix (only the diagonal is saved, indicated with D instead of X:
+\code
+<m>3D3; 1 2 3</m>
+\endcode
+
+*/
+
+#endif        //  #ifndef EIGENBOOSTSERIALIZATION_HPP
+

--- a/src/dmpbbo_io/EigenFileIO.hpp
+++ b/src/dmpbbo_io/EigenFileIO.hpp
@@ -25,7 +25,7 @@
 
 #ifndef EIGENSAVEMATRIX_HPP
 #define EIGENSAVEMATRIX_HPP
-
+#define EIGEN2_SUPPORT
 #include <string>
 #include <fstream>
 #include <iostream>

--- a/src/dmpbbo_io/EigenFileIO.hpp~
+++ b/src/dmpbbo_io/EigenFileIO.hpp~
@@ -1,0 +1,71 @@
+/**
+ * @file EigenFileIO.hpp
+ * @brief  Header file for input/output of Eigen matrices to ASCII files.
+ * @author Freek Stulp
+ *
+ * Implementations are in the tpp file
+ *
+ * This file is part of DmpBbo, a set of libraries and programs for the 
+ * black-box optimization of dynamical movement primitives.
+ * Copyright (C) 2014 Freek Stulp, ENSTA-ParisTech
+ * 
+ * DmpBbo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ * 
+ * DmpBbo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef EIGENSAVEMATRIX_HPP
+#define EIGENSAVEMATRIX_HPP
+//#define EIGEN2_SUPPORT
+#include <string>
+#include <fstream>
+#include <iostream>
+
+#include <boost/filesystem.hpp>
+
+#include <eigen3/Eigen/Core>
+
+namespace DmpBbo {
+
+/** Load an Eigen matrix from an ASCII file.
+ * \param[in] filename Name of the file from which to read the matrix
+ * \param[out] m The matrix that was read from file
+ * \return true if loading was successful, false otherwise
+ */ 
+template<typename Scalar, int RowsAtCompileTime, int ColsAtCompileTime>
+bool loadMatrix(std::string filename, Eigen::Matrix<Scalar,RowsAtCompileTime,ColsAtCompileTime>& m);
+
+/** Save an Eigen matrix to an ASCII file.
+ * \param[in] filename Name of the file to which to save the matrix
+ * \param[in] matrix The matrix to save to file
+ * \param[in] overwrite Whether to overwrite any existing files
+ * \return true if saving was successful, false otherwise
+ */ 
+template<typename Scalar, int RowsAtCompileTime, int ColsAtCompileTime>
+bool saveMatrix(std::string filename, Eigen::Matrix<Scalar,RowsAtCompileTime,ColsAtCompileTime> matrix, bool overwrite=false);
+
+/** Save an Eigen matrix to an ASCII file.
+ * \param[in] directory Name of the directory to which to save the matrix
+ * \param[in] filename Name of the file to which to save the matrix
+ * \param[in] matrix The matrix to save to file
+ * \param[in] overwrite Whether to overwrite any existing files
+ * \return true if saving was successful, false otherwise
+ */ 
+template<typename Scalar, int RowsAtCompileTime, int ColsAtCompileTime>
+bool saveMatrix(std::string directory, std::string filename, Eigen::Matrix<Scalar,RowsAtCompileTime,ColsAtCompileTime> matrix, bool overwrite=false);
+
+#include "EigenFileIO.tpp"
+
+}
+
+#endif        //  #ifndef EIGENSAVEMATRIX_HPP
+

--- a/src/dynamicalsystems/DynamicalSystem.cpp
+++ b/src/dynamicalsystems/DynamicalSystem.cpp
@@ -3,24 +3,24 @@
  * @brief  DynamicalSystem class source file.
  * @author Freek Stulp
  *
- * This file is part of DmpBbo, a set of libraries and programs for the 
+ * This file is part of DmpBbo, a set of libraries and programs for the
  * black-box optimization of dynamical movement primitives.
  * Copyright (C) 2014 Freek Stulp, ENSTA-ParisTech
- * 
+ *
  * DmpBbo is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 2 of the License, or
  * (at your option) any later version.
- * 
+ *
  * DmpBbo is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
  */
-#define EIGEN2_SUPPORT 
+#define EIGEN2_SUPPORT
 #include "dynamicalsystems/DynamicalSystem.hpp"
 
 #include <cmath>
@@ -33,7 +33,7 @@ using namespace Eigen;
 namespace DmpBbo {
 
 DynamicalSystem::DynamicalSystem(int order, double tau, VectorXd initial_state, VectorXd attractor_state, string name)
-  : 
+  :
   // For 1st order systems, the dimensionality of the state vector 'x' is 'dim'
   // For 2nd order systems, the system is expanded to x = [y z], where 'y' and
   // 'z' are both of dimensionality 'dim'. Therefore dim(x) is 2*dim
@@ -58,16 +58,16 @@ void DynamicalSystem::integrateStart(const VectorXd& x_init, Ref<VectorXd> x, Re
 }
 
 void DynamicalSystem::integrateStart(Ref<VectorXd> x, Ref<VectorXd> xd) const {
-  // Check size. Leads to faster numerical integration and makes Eigen::Ref easier to deal with   
+  // Check size. Leads to faster numerical integration and makes Eigen::Ref easier to deal with
   assert(x.size()==dim());
   assert(xd.size()==dim());
-  
+
   // Return value for state variables
-  // Pad the end with zeros: Why? In the spring-damper system, the state consists of x = [y z]. 
-  // The initial state only applies to y. Therefore, we set x = [y 0]; 
+  // Pad the end with zeros: Why? In the spring-damper system, the state consists of x = [y z].
+  // The initial state only applies to y. Therefore, we set x = [y 0];
   x.fill(0);
   x.segment(0,initial_state_.size()) = initial_state_;
-  
+
   // Return value (rates of change)
   differentialEquation(x,xd);
 }
@@ -75,7 +75,8 @@ void DynamicalSystem::integrateStart(Ref<VectorXd> x, Ref<VectorXd> xd) const {
 void DynamicalSystem::integrateStep(double dt, const Ref<const VectorXd> x, Ref<VectorXd> x_updated, Ref<VectorXd> xd_updated) const
 {
   assert(dt>0.0);
-  // Check size. Leads to faster numerical integration and makes Eigen::Ref easier to deal with   
+  if (dt>0.01) {std::cout<<"WARNING: The selected timestep, dt, may be numerically instable. Consider choosing dt < 0.01."<<std::endl;}
+  // Check size. Leads to faster numerical integration and makes Eigen::Ref easier to deal with
   assert(x.size()==dim());
   if (integration_method_ == RUNGE_KUTTA)
     integrateStepRungeKutta(dt, x, x_updated, xd_updated);
@@ -95,7 +96,7 @@ void DynamicalSystem::integrateStepRungeKutta(double dt, const Ref<const VectorX
 {
   // 4th order Runge-Kutta for a 1st order system
   // http://en.wikipedia.org/wiki/Runge-Kutta_method#The_Runge.E2.80.93Kutta_method
-  
+
   int l = x.size();
   VectorXd k1(l), k2(l), k3(l), k4(l);
   differentialEquation(x,k1);
@@ -105,9 +106,9 @@ void DynamicalSystem::integrateStepRungeKutta(double dt, const Ref<const VectorX
   differentialEquation(input_k3,k3);
   VectorXd input_k4 = x + dt*k3;
   differentialEquation(input_k4,k4);
-      
+
   x_updated = x + dt*(k1 + 2.0*(k2+k3) + k4)/6.0;
-  differentialEquation(x_updated,xd_updated); 
+  differentialEquation(x_updated,xd_updated);
 }
 
 }

--- a/src/dynamicalsystems/DynamicalSystem.cpp
+++ b/src/dynamicalsystems/DynamicalSystem.cpp
@@ -75,7 +75,7 @@ void DynamicalSystem::integrateStart(Ref<VectorXd> x, Ref<VectorXd> xd) const {
 void DynamicalSystem::integrateStep(double dt, const Ref<const VectorXd> x, Ref<VectorXd> x_updated, Ref<VectorXd> xd_updated) const
 {
   assert(dt>0.0);
-  if (dt>0.01) {std::cout<<"WARNING: The selected timestep, dt, may be numerically instable. Consider choosing dt < 0.01."<<std::endl;}
+  //if (dt>0.01) {std::cout<<"WARNING: The selected timestep, dt, may be numerically instable. Consider choosing dt < 0.01."<<std::endl;}
   // Check size. Leads to faster numerical integration and makes Eigen::Ref easier to deal with
   assert(x.size()==dim());
   if (integration_method_ == RUNGE_KUTTA)

--- a/src/dynamicalsystems/DynamicalSystem.cpp
+++ b/src/dynamicalsystems/DynamicalSystem.cpp
@@ -20,7 +20,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
  */
- 
+#define EIGEN2_SUPPORT 
 #include "dynamicalsystems/DynamicalSystem.hpp"
 
 #include <cmath>

--- a/src/dynamicalsystems/DynamicalSystem.cpp~
+++ b/src/dynamicalsystems/DynamicalSystem.cpp~
@@ -1,0 +1,113 @@
+/**
+ * @file   DynamicalSystem.cpp
+ * @brief  DynamicalSystem class source file.
+ * @author Freek Stulp
+ *
+ * This file is part of DmpBbo, a set of libraries and programs for the 
+ * black-box optimization of dynamical movement primitives.
+ * Copyright (C) 2014 Freek Stulp, ENSTA-ParisTech
+ * 
+ * DmpBbo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ * 
+ * DmpBbo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
+#include "dynamicalsystems/DynamicalSystem.hpp"
+
+#include <cmath>
+#include <iostream>
+#include <eigen3/Eigen/Core>
+
+using namespace std;
+using namespace Eigen;
+
+namespace DmpBbo {
+
+DynamicalSystem::DynamicalSystem(int order, double tau, VectorXd initial_state, VectorXd attractor_state, string name)
+  : 
+  // For 1st order systems, the dimensionality of the state vector 'x' is 'dim'
+  // For 2nd order systems, the system is expanded to x = [y z], where 'y' and
+  // 'z' are both of dimensionality 'dim'. Therefore dim(x) is 2*dim
+  dim_(initial_state.size()*order),
+  // The dimensionality of the system before a potential rewrite
+  dim_orig_(initial_state.size()),
+  tau_(tau),initial_state_(initial_state),attractor_state_(attractor_state),
+  name_(name),integration_method_(RUNGE_KUTTA)
+{
+  assert(order==1 || order==2);
+  assert(initial_state.size()==attractor_state.size());
+}
+
+DynamicalSystem::~DynamicalSystem(void)
+{
+}
+
+void DynamicalSystem::integrateStart(const VectorXd& x_init, Ref<VectorXd> x, Ref<VectorXd> xd)
+{
+  set_initial_state(x_init);
+  integrateStart(x,xd);
+}
+
+void DynamicalSystem::integrateStart(Ref<VectorXd> x, Ref<VectorXd> xd) const {
+  // Check size. Leads to faster numerical integration and makes Eigen::Ref easier to deal with   
+  assert(x.size()==dim());
+  assert(xd.size()==dim());
+  
+  // Return value for state variables
+  // Pad the end with zeros: Why? In the spring-damper system, the state consists of x = [y z]. 
+  // The initial state only applies to y. Therefore, we set x = [y 0]; 
+  x.fill(0);
+  x.segment(0,initial_state_.size()) = initial_state_;
+  
+  // Return value (rates of change)
+  differentialEquation(x,xd);
+}
+
+void DynamicalSystem::integrateStep(double dt, const Ref<const VectorXd> x, Ref<VectorXd> x_updated, Ref<VectorXd> xd_updated) const
+{
+  assert(dt>0.0);
+  // Check size. Leads to faster numerical integration and makes Eigen::Ref easier to deal with   
+  assert(x.size()==dim());
+  if (integration_method_ == RUNGE_KUTTA)
+    integrateStepRungeKutta(dt, x, x_updated, xd_updated);
+  else
+    integrateStepEuler(dt, x, x_updated, xd_updated);
+}
+
+
+void DynamicalSystem::integrateStepEuler(double dt, const Ref<const VectorXd> x, Ref<VectorXd> x_updated, Ref<VectorXd> xd_updated) const
+{
+  // simple Euler integration
+  differentialEquation(x,xd_updated);
+  x_updated  = x + dt*xd_updated;
+}
+
+void DynamicalSystem::integrateStepRungeKutta(double dt, const Ref<const VectorXd> x, Ref<VectorXd> x_updated, Ref<VectorXd> xd_updated) const
+{
+  // 4th order Runge-Kutta for a 1st order system
+  // http://en.wikipedia.org/wiki/Runge-Kutta_method#The_Runge.E2.80.93Kutta_method
+  
+  int l = x.size();
+  VectorXd k1(l), k2(l), k3(l), k4(l);
+  differentialEquation(x,k1);
+  VectorXd input_k2 = x + dt*0.5*k1;
+  differentialEquation(input_k2,k2);
+  VectorXd input_k3 = x + dt*0.5*k2;
+  differentialEquation(input_k3,k3);
+  VectorXd input_k4 = x + dt*k3;
+  differentialEquation(input_k4,k4);
+      
+  x_updated = x + dt*(k1 + 2.0*(k2+k3) + k4)/6.0;
+  differentialEquation(x_updated,xd_updated); 
+}
+
+}

--- a/src/dynamicalsystems/DynamicalSystem.hpp
+++ b/src/dynamicalsystems/DynamicalSystem.hpp
@@ -23,7 +23,7 @@
 
 #ifndef _DYNAMICALSYSTEM_H_
 #define _DYNAMICALSYSTEM_H_
-
+#define EIGEN2_SUPPORT
 #include <string>
 #include <vector>
 #include <eigen3/Eigen/Core>

--- a/src/dynamicalsystems/DynamicalSystem.hpp~
+++ b/src/dynamicalsystems/DynamicalSystem.hpp~
@@ -1,0 +1,597 @@
+/**
+ * @file DynamicalSystem.hpp
+ * @brief  DynamicalSystem class header file.
+ * @author Freek Stulp
+ *
+ * This file is part of DmpBbo, a set of libraries and programs for the 
+ * black-box optimization of dynamical movement primitives.
+ * Copyright (C) 2014 Freek Stulp, ENSTA-ParisTech
+ * 
+ * DmpBbo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ * 
+ * DmpBbo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#define EIGEN2_SUPPORT
+#ifndef _DYNAMICALSYSTEM_H_
+#define _DYNAMICALSYSTEM_H_
+
+#include <string>
+#include <vector>
+#include <eigen3/Eigen/Core>
+
+#include "dmpbbo_io/EigenBoostSerialization.hpp"
+
+namespace DmpBbo {
+
+/** \defgroup DynamicalSystems Dynamical Systems
+ */
+
+/** \brief Interface for implementing dynamical systems. Other dynamical systems should inherit from this class.
+ *
+ * Two pure virtual functions that each DynamicalSystem subclass should implement are
+ * \li differentialEquation() : The differential equation that defines the system
+ * \li analyticalSolution() : The analytical solution to the system at given times
+ *
+ * This class provides accesor/mutator methods for some variables typically found in
+ * dynamical systems:
+ * \li dim() The dimensionality of the system, i.e. the number of variables in the state vector.
+ * \li tau() The time constant of the system
+ * \li initial_state() The initial state of the system
+ * \li attractor_state() The attractor state, i.e. the state to which the system will converge
+ *
+ * This class also provides functionality for integrating a dynamical system by repeatidly
+ * calling it's differentialEquation, and doing simple Euler or 4th-order Runge-Kutta integration.
+ * The related functions are:
+ * \li set_integration_method(IntegrationMethod), i.e. EULER or RUNGE_KUTTA
+ * \li integrateStep() Integrate the system one time step, using the current integration method
+ * \li integrateStart() Start integrating the system (does not require the current state to be passed)
+ *
+ * \ingroup DynamicalSystems
+ */
+class DynamicalSystem
+{
+
+public:
+  
+  /** @name Constructors/Destructor
+   *  @{
+   */ 
+
+  /**
+   * Initialization constructor.
+   * \param order            Order of the system
+   * \param tau              Time constant, see tau()
+   * \param initial_state    Initial state, see initial_state()
+   * \param attractor_state  Attractor state, see attractor_state()
+   * \param name             A name you give, see name()
+   */
+   DynamicalSystem(int order, double tau, Eigen::VectorXd initial_state, Eigen::VectorXd attractor_state, std::string name);
+
+  /** Destructor */
+  virtual ~DynamicalSystem(void);
+
+  /** Return a pointer to a deep copy of the DynamicalSystem object.
+   *  \return Pointer to a deep copy
+   */
+  virtual DynamicalSystem* clone(void) const = 0;
+  
+  /** @} */ 
+   
+  /** @name Main DynamicalSystem functions
+   *  @{
+   */
+   
+  /**
+   * The differential equation which defines the system.
+   * It relates state values to rates of change of those state values
+   *
+   * \param[in]  x  current state (column vector of size dim() X 1)
+   * \param[out] xd rate of change in state (column vector of size dim() X 1)
+   *
+   * \remarks x and xd should be of size dim() X 1. This forces you to pre-allocate memory, which
+   * speeds things up (and also makes Eigen's Ref functionality easier to deal with).
+   */
+   virtual void differentialEquation(const Eigen::VectorXd& x, Eigen::Ref<Eigen::VectorXd> xd) const = 0;
+
+
+  /**
+   * Return analytical solution of the system at certain times
+   *
+   * \param[in]  ts  A vector of times for which to compute the analytical solutions
+   * \param[out] xs  Sequence of state vectors. T x D or D x T matrix, where T is the number of times (the length of 'ts'), and D the size of the state (i.e. dim())
+   * \param[out] xds Sequence of state vectors (rates of change). T x D or D x T matrix, where T is the number of times (the length of 'ts'), and D the size of the state (i.e. dim())
+   *
+   * \remarks The output xs and xds will be of size D x T \em only if the matrix x you pass as an argument of size D x T. In all other cases (i.e. including passing an empty matrix) the size of x will be T x D. This feature has been added so that you may pass matrices of either size. 
+   */
+  virtual void analyticalSolution(const Eigen::VectorXd& ts, Eigen::MatrixXd& xs, Eigen::MatrixXd& xds) const  = 0;
+
+  /** Start integrating the system
+   *
+   * \param[out] x               - The first vector of state variables
+   * \param[out] xd              - The first vector of rates of change of the state variables
+   *
+   * \remarks x and xd should be of size dim() X 1. This forces you to pre-allocate memory, which
+   * speeds things up (and also makes Eigen's Ref functionality easier to deal with).
+   */
+  virtual void integrateStart(Eigen::Ref<Eigen::VectorXd> x, Eigen::Ref<Eigen::VectorXd> xd) const;
+
+  /** Start integrating the system with a new initial state
+   *
+   * \param[in]  x_init          - The initial state vector
+   * \param[out] x               - The first vector of state variable
+   * \param[out] xd              - The first vector of rates of change of the state variables
+   *
+   */
+  void integrateStart(const Eigen::VectorXd& x_init, Eigen::Ref<Eigen::VectorXd> x, Eigen::Ref<Eigen::VectorXd> xd);
+
+  /**
+   * Integrate the system one time step.
+   *
+   * \param[in]  dt         Duration of the time step
+   * \param[in]  x          Current state
+   * \param[out] x_updated  Updated state, dt time later.
+   * \param[out] xd_updated Updated rates of change of state, dt time later.
+   *
+   * \remarks x should be of size dim() X 1. This forces you to pre-allocate memory, which
+   * speeds things up (and also makes Eigen's Ref functionality easier to deal with).
+   */
+  virtual void integrateStep(double dt, const Eigen::Ref<const Eigen::VectorXd> x, Eigen::Ref<Eigen::VectorXd> x_updated, Eigen::Ref<Eigen::VectorXd> xd_updated) const;
+
+  /** @} */ 
+  
+  /** @name Input/Output
+   *  @{
+   */ 
+
+  /** Write a DynamicalSystem to an output stream.
+   *
+   *  \param[in] output  Output stream to which to write to
+   *  \param[in] dyn_sys Dynamical system to write
+   *  \return    Output stream
+   *
+   *  \remarks Calls pure virtual function toString(), which must be implemented by
+   *  all subclasses: http://stackoverflow.com/questions/4571611/virtual-operator
+   */
+  friend std::ostream& operator<<(std::ostream& output, const DynamicalSystem& dyn_sys) {
+    output << dyn_sys.toString();
+    return output;
+  }
+
+  /** Returns a string representation of the object.
+   * \return A string representation of the object.
+   */
+  virtual std::string toString(void) const = 0;
+
+  /** @} */ 
+  
+  /** @name Accessor functions
+   *  @{
+   */
+
+
+  /** The possible integration methods that can be used.
+   * \li EULER: simple Euler method (http://en.wikipedia.org/wiki/Euler_integration)
+   * \li RUNGE_KUTTA: 4th-order Runge-Kutta (http://en.wikipedia.org/wiki/List_of_Runge%E2%80%93Kutta_methods#Classic_fourth-order_method)
+   */
+  enum IntegrationMethod { EULER, RUNGE_KUTTA };
+
+  /** Choose the integration method.
+   *  \param[in] integration_method The integration method, see DynamicalSystem::IntegrationMethod.
+   */
+  inline void set_integration_method(IntegrationMethod integration_method) {
+    integration_method_ = integration_method;
+  }
+
+  /**
+   * Get the dimensionality of the dynamical system, i.e. the length of its state vector.
+   * \return Dimensionality of the dynamical system
+   */
+  inline int dim(void) const {
+    return dim_;
+  }
+
+  /**
+   * Get the dimensionality of the dynamical system, i.e. the length of its output.
+   *
+   * 2nd order systems are represented as 1st order systems with an expanded state. The
+   * SpringDamperSystem for instance is represented as x = [y z], xd = [yd zd].
+   * DynamicalSystem::getDim returns dim(x) = dim([y z]) = 2*dim(y)
+   * DynamicalSystem::dim_orig returns dim(y) = dim()/2
+   *
+   * For Dynamical Movement Primitives, dim_orig() may be for instance 3, if the output of the DMP
+   * represents x,y,z coordinates. However, dim() will have a much larger dimensionality, because it 
+   * also contains the variables of all the subsystems (phase system, gating system, etc.)
+   * 
+   * \return Original dimensionality of the dynamical system
+   */
+   inline int dim_orig(void) const {
+    return dim_orig_;
+   }
+
+  /**
+   * Accessor function for the time constant.
+   * \return Time constant
+   */
+  inline double tau(void) const { return tau_; }
+
+  /**
+   * Mutator function for the time constant.
+   * \param[in] tau Time constant
+   */
+  inline virtual void set_tau(double tau) {
+    assert(tau>0.0);
+    tau_ = tau;
+  }
+
+  /**
+   * Accessor function for the initial state of the dynamical system.
+   * \return Initial state of the dynamical system.
+   */
+  inline Eigen::VectorXd initial_state(void) const { return initial_state_; }
+
+  /** Mutator function for the initial state of the dynamical system.
+   *  \param[in] initial_state Initial state of the dynamical system.
+   */
+  inline virtual void set_initial_state(const Eigen::VectorXd& initial_state) {
+    assert(initial_state.size()==dim_orig_);
+    initial_state_ = initial_state;
+  }
+
+  /**
+   * Accessor function for the attractor state of the dynamical system.
+   * \return Attractor state of the dynamical system.
+   */
+  inline Eigen::VectorXd attractor_state(void) const { return attractor_state_; }
+
+  /** Mutator function for the attractor state of the dynamical system.
+   *  \param[in] attractor_state Attractor state of the dynamical system.
+   */
+  inline virtual void set_attractor_state(const Eigen::VectorXd& attractor_state) {
+    assert(attractor_state.size()==dim_orig_);
+    attractor_state_ = attractor_state;
+  }
+
+  /**
+   * Accessor function for the name of the dynamical system.
+   * \return Name of the dynamical system.
+   */
+  inline std::string name(void) const { return name_; }
+
+  /** Mutator function for the name of the dynamical system.
+   *  \param[in] name Name of the dynamical system.
+   */
+  inline virtual void set_name(std::string name) {
+    name_ = name;
+  }
+  
+protected:
+  /**
+   * Set the dimensionality of the dynamical system, i.e. the length of its state vector.
+   * \param[in] dim Dimensionality of the dynamical system
+   */
+  inline void set_dim(int dim) {
+    dim_ = dim;
+  }
+
+  /** @} */
+  
+private:
+
+  /**
+   * Integrate the system one time step using simple Euler integration
+   *
+   * \param[in]  dt         Duration of the time step
+   * \param[in]  x          Current state
+   * \param[out] x_updated  Updated state, dt time later.
+   * \param[out] xd_updated Updated rates of change of state, dt time later.
+   */
+  void integrateStepEuler(double dt, const Eigen::Ref<const Eigen::VectorXd> x, Eigen::Ref<Eigen::VectorXd> x_updated, Eigen::Ref<Eigen::VectorXd> xd_updated) const;
+
+  /**
+   * Integrate the system one time step using 4th order Runge-Kutta integration
+   *
+   * \param[in]  dt         Duration of the time step
+   * \param[in]  x          Current state
+   * \param[out] x_updated  Updated state, dt time later.
+   * \param[out] xd_updated Updated rates of change of state, dt time later.
+   */
+  void integrateStepRungeKutta(double dt, const Eigen::Ref<const Eigen::VectorXd> x, Eigen::Ref<Eigen::VectorXd> x_updated, Eigen::Ref<Eigen::VectorXd> xd_updated) const;
+
+  /** Dimensionality of the system.
+   *  For instance, if there are 3 state variables, dim_ is 3.
+   */
+  int dim_;
+
+ /** The original dimensionality of the system, see DynamicalSystem::dim_orig()
+  */
+ int dim_orig_;
+
+  /** Time constant
+   *  \remarks The reason that tau_ is protected and not private is that it is usually required by
+   *  DynamicalSystem::differentialEquation, which should be as fast as possible (i.e. to avoid
+   *  function calls).
+   */
+  double tau_;
+
+  /** The initial state of the system.
+   *  It is a column vector of size dim_orig().
+   */
+  Eigen::VectorXd initial_state_;
+
+  /** The attractor state of the system, to which the system will converge.
+   *  It is a column vector of size dim_orig()
+   *  \remarks The reason that attractor_state_ is protected and not private is that it is usually
+   *  required by DynamicalSystem::differentialEquation, which should be as fast as possible (i.e.
+   *  to avoid function calls and copying of vectors).
+   */
+  Eigen::VectorXd attractor_state_;
+
+  /** A name you may give to the system.
+   * Has no direct functionality, but may perhaps be useful for output or debugging purposes.
+   */
+  std::string name_;
+
+  /** Which integration method to use. See DynamicalSystem::IntegrationMethod */
+  IntegrationMethod integration_method_;
+  
+
+protected:
+  /**
+   * Default constructor.
+   * \remarks This default constuctor is required for boost::serialization to work. See \ref sec_boost_serialization_ugliness
+   */
+  DynamicalSystem(void) {};
+   
+private:
+  /** Give boost serialization access to private members. */  
+  friend class boost::serialization::access;
+  
+  /** Serialize class data members to boost archive. 
+   * \param[in] ar Boost archive
+   * \param[in] version Version of the class
+   * See http://www.boost.org/doc/libs/1_55_0/libs/serialization/doc/tutorial.html#simplecase
+   */
+  template<class Archive>
+  void serialize(Archive & ar, const unsigned int version)
+  {
+    ar & BOOST_SERIALIZATION_NVP(dim_);
+    ar & BOOST_SERIALIZATION_NVP(dim_orig_);
+    // Const doesn't work, see sec_boost_serialization_ugliness in the docu
+    //ar & boost::serialization::make_nvp("dim_orig_", const_cast<int&>(dim_orig_));
+    ar & BOOST_SERIALIZATION_NVP(tau_);
+    ar & BOOST_SERIALIZATION_NVP(initial_state_);
+    ar & BOOST_SERIALIZATION_NVP(attractor_state_);
+    ar & BOOST_SERIALIZATION_NVP(name_);
+    ar & BOOST_SERIALIZATION_NVP(integration_method_);
+  }
+
+};
+
+}
+
+#include <boost/serialization/assume_abstract.hpp>
+/** Don't add version information to archives. */
+BOOST_SERIALIZATION_ASSUME_ABSTRACT(DmpBbo::DynamicalSystem);
+ 
+#include <boost/serialization/export.hpp>
+/** Don't add version information to archives. */
+BOOST_CLASS_IMPLEMENTATION(DmpBbo::DynamicalSystem,boost::serialization::object_serializable);
+
+#endif // _DYNAMICALSYSTEM_H_
+
+
+
+/** \page page_dyn_sys Dynamical Systems Module
+
+\section sec_dyn_sys_intro Introduction
+
+Let a \em state be a vector of real numbers. A dynamical system consists of such a state and a rule that describes how this state will change over time; it describes what future state follows from the current state. A typical example is radioactive decay, where the state \f$x\f$ is the number of atoms, and the rate of decay is \f$\frac{dx}{dt}\f$  proportional to \f$x\f$: \f$ \frac{dx}{dt} = -\alpha x\f$. Here, \f$\alpha\f$ is the `decay constant' and \f$\dot{x}\f$ is a shorthand for \f$\frac{dx}{dt}\f$. Such an evolution rule describes an implicit relation between the current state \f$ x(t) \f$ and the state a short time in the future \f$x(t+dt)\f$.
+
+If we know the initial state of a dynamical system, e.g. \f$x_0\equiv x(0)=4\f$, we may compute the evolution of the state over time through \em numerical \em integration. This means we take the initial state \f$ x_0\f$, and iteratively compute subsequent states \f$x(t+dt)\f$ by computing the rate of change \f$\dot{x}\f$, and integrating this over the small time interval \f$dt\f$. A pseudo-code example is shown below for  \f$x_0\equiv x(0)=4\f$, \f$dt=0.01s\f$ and  \f$\alpha=6\f$.
+
+\code
+alpha=6; // Decay constant
+dt=0.01; // Duration of one integration step
+x=4.0;   // Initial state
+t=0.0;   // Initial time
+while (t<1.5) {
+  dx = -alpha*x;  // Dynamical system rule
+  x = x + dx*dt;  // Project x into the future for a small time step dt (Euler integration)
+  t = t + dt;     // The future is now!
+}
+\endcode
+
+This procedure is called ``integrating the system'', and leads the trajectory plotted below (shown for both \f$\alpha=6\f$ and \f$\alpha=3\f$.
+
+\image html exponential_decay-svg.png "Evolution of the exponential dynamical system."
+\image latex exponential_decay-svg.pdf "Evolution of the exponential dynamical system." height=4cm
+
+The evolution of many dynamical systems can also be determined analytically, by explicitly solving the differential equation. For instance, \f$N(t) = x_0e^{-\alpha t}\f$ is the solution
+to \f$\dot{x} = -\alpha x\f$. Why? Let's plug \f$x(t) = x_0e^{-\alpha t}\f$ into \f$\frac{dx}{dt} = -\alpha x\f$, which leads to \f$\frac{d}{dt}(x_0e^{-\alpha t}) = -\alpha (x_0e^{-\alpha t})\f$. Then derive the left side of the equations, which yields \f$-\alpha(x_0e^{-\alpha t}) = -\alpha (x_0e^{-\alpha t})\f$. QED. Note that the solution works for arbitrary \f$x_0\f$. It should, because the solution should not depend on the initial state.
+
+\subsection dynsys_implementation1 Implementation
+
+<em>
+In the object-oriented implementation of this module, all dynamical systems inherit from the abstract DynamicalSystem class. The analytical solution of a dynamical system is computed with DynamicalSystem::analyticalSolution, which takes the times \c ts at which the solution should be computed, and returns the evolution of the system as \c xs and \c xds.
+
+A system's differential equation is implement in the function DynamicalSystem::differentialEquation, which takes the current state \c x, and computes the rates of change \c xd. The functions DynamicalSystem::integrateStart() and DynamicalSystem::integrateStep() are then used to numerically integrate the system as follows (using the example plotted above):
+
+\code
+// Make exponential system that decays from 4 to 0 with decay constant 6, and tau=1.0
+double alpha = 6.0;                // Decay constant
+double tau = 1.0;                  // Time constant 
+VectorXd x_init(1); x_init << 4.0; // Initial state (a 1D vector with the value 4.0 inside using Eigen comma initializer)
+VectorXd x_attr(1); x_attr << 0.0; // Attractor state
+DynamicalSystem* dyn_sys = new ExponentialSystem(tau, x_init, x_attr, alpha);
+
+Eigen::VectorXd x, xd;
+dyn_sys->integrateStart(x,xd); // Start the integration
+double dt = 0.01;
+for (double t=0.0; t<1.5; t+=dt)
+{
+  dyn_sys->integrateStep(dt,x,x,xd);          // Takes current state x, integrates system, and writes next state in x, xd
+  cout << t << " " << x << " " << xd << endl; // Output current time, state and rate of change
+}
+delete dyn_sys;
+\endcode
+
+\em Remark. Both analyticalSolution and differentialEquation functions above are const, i.e. they do not change the DynamicalSystem itself.
+
+
+\subsection dynsys_implementation1_plotting Plotting
+
+If you save the output of a dynamical in a file with format (where D is the dimensionality of the system, and T is the number of time steps)
+\verbatim
+x^0_0 x^1_0 .. x^D_0   xd^0_0 xd^1_0 .. xd^D_0   t_0   
+x^0_1 x^1_1 .. x^D_1   xd^0_1 xd^1_1 .. xd^D_1   t_1   
+   :     :       :         :      :       :       :    
+x^0_T x^1_T .. x^D_T   xd^0_T xd^1_T .. xd^D_T   t_T   
+\endverbatim
+you can plot this output with 
+\code
+python dynamicalsystems/plotting/plotDynamicalSystem.py file.txt
+\endcode
+
+\subsection dynsys_implementation1_demo Demos
+
+A demonstration of how to initialize and integrate an ExponentialSystem is in demoExponentialSystem.cpp
+
+A more complete demonstration including all implemented dynamical systems is in demoDynamicalSystems.cpp. If you call the resulting executable with a directory argument, e.g.
+\code
+./demoDynamicalSystems /tmp/demoDynamicalSystems
+\endcode
+it will save results to file, which you can plot with for instance:
+\code
+python plotDynamicalSystem.py /tmp/demoDynamicalSystems/ExponentialSystem/results_rungekutta.txt
+python plotDynamicalSystem.py /tmp/demoDynamicalSystems/ExponentialSystem/results_euler.txt
+\endcode
+Different test can be performed with the dynamical system. The test can be chosen by passing further argument, e.g. 
+\code
+./demoDynamicalSystems /tmp/demoDynamicalSystems rungekutta euler
+\endcode
+will integrate the dynamical systems with both the Runge-Kutta and simple Euler method. The available tests are:
+\li "rungekutta" - Use 4th-order Runge-Kutta integration (more accurate, but more calls of DynamicalSystem::differentialEquation)
+\li "euler"      - Use simple Euler integration (less accurate, but faster)
+\li "analytical" - Use the analytical solution instead of numerical integration
+\li "tau"        - Change tau before doing numerical integration
+\li "attractor"  - Change the attractor state during numerical integration
+\li "perturb"    - Perturb the state during numerical integration
+
+To compare for instance the analytical solution with the Runge-Kutta integration in a plot, you can do
+\code
+python plotDynamicalSystemComparison.py /tmp/demoDynamicalSystems/ExponentialSystem/results_analytical.txt  /tmp/demoDynamicalSystems/ExponentialSystem/results_rungekutta.txt
+\endcode
+
+
+</em>
+
+\section sec_dyn_sys_properties Properties and Features of Linear Dynamical Systems
+
+\subsection sec_dyn_sys_convergence Convergence towards the Attractor
+
+In the limit of time, the dynamical system for exponential decay will converge to 0 (i.e. \f$x(\infty) = x_0e^{-\alpha\infty}  = 0\f$). The value 0 is known as the \em attractor of the system.
+For simple dynamical systems, it is possible to \em proove that they will converge towards the attractor.
+
+Suppose that the attractor state in our running example is not 0, but 1. In that case, we change the attractor state of the exponential decay to \f$x^g\f$ (\f$g\f$=goal) and define the following differential equation:
+\f{eqnarray*}{
+\dot{x}  =& -\alpha(x-x^g)                & \mbox{~with attractor } x^g
+\f}
+
+This system will now converge to the attractor state \f$x^g\f$, rather than 0.
+
+\image html change_tau_attr-svg.png "Changing the attractor state or time constant."
+\image latex change_tau_attr-svg.pdf "Changing the attractor state or time constant." height=4cm
+
+\subsection sec_dyn_sys_perturbations Robustness to Perturbations
+
+Another nice feature of dynamical systems is their robustness to perturbations, which means that they will converge towards the attractor even if they are perturbed. The figure below shows how the perturbed system (cyan) converges towards the attractor state just as the unperturbed system (blue) does.
+
+\image html perturb-svg.png "Perturbing the dynamical system."
+\image latex perturb-svg.pdf "Perturbing the dynamical system." height=4cm
+
+
+\subsection sec_dyn_sys_time_constant Changing the speed of convergence: The time constant
+
+The rates of change computed by the differential equation can be increased or decreased (leading to a faster or slower convergence) with a \em time \em constant, which is usually written as follows:
+
+\f{eqnarray*}{
+\tau\dot{x}  =& -\alpha(x-x^g)\\
+\dot{x}  =& (-\alpha(x-x^g))/\tau
+\f}
+
+\em Remark. For an exponential system, decreasing the time constant \f$\tau\f$ has the same effect as increasing  \f$\alpha\f$. For more complex dynamical systems with several parameters, it is useful to have a separate parameter that changes only the speed of convergence, whilst leaving the other parameters the same.
+
+\subsection sec_dyn_sys_multi Multi-dimensional states
+
+The state \f$x\f$ need not be a scalar, but may be a vector. This then represents a multi-dimensional state, i.e. \f$\tau\dot{\mathbf{x}}  = -\alpha(\mathbf{x}-\mathbf{x}^g)\f$. In the code, the size of the state vector \f$dim(\mathbf{x})\equiv dim(\dot{\mathbf{x}})\f$ of a dynamical system is returned by the function DynamicalSystem::dim()
+
+\subsection sec_dyn_sys_autonomy Autonomy
+
+Dynamical system that do not depend on time are called \em autonomous. For instance, the formula \f$ \dot{x}  = -\alpha x\f$ does not depend on time, which means the exponential system is autonomous.
+
+
+\subsection Implementation
+<em>
+The attractor state and time constant of a dynamical system are usually passed to the constructor. They can be changed afterwards with with DynamicalSystem::set_attractor_state and DynamicalSystem::set_tau. Before integration starts, the initial state can be set with  DynamicalSystem::set_initial_state. This influences the output of DynamicalSystem::integrateStart, but not DynamicalSystem::integrateStep.
+
+Further (first order) linear dynamical systems that are implemented in this module is a SigmoidSystem (see
+ http://en.wikipedia.org/wiki/Exponential_decay and http://en.wikipedia.org/wiki/Sigmoid_function), as well as a dynamical system that has a constant velocity (TimeSystem), so as to mimic the passing of time (time moves at a constant rate per time ;-)
+ 
+\f{eqnarray*}{
+\dot{x}  =& -\alpha (x-x^g)    & \mbox{exponential decay/growth} \label{equ_}\\
+\dot{x}  =& \alpha x (\beta-x) & \mbox{sigmoid} \label{equ_}\\
+\dot{x}  =& 1/\tau             & \mbox{constant velocity (mimics the passage of time)} \label{equ_}\\
+\f}
+
+\image html sigmoid-svg.png "Exponential (blue) and sigmoid (purple) dynamical systems."
+\image latex sigmoid-svg.pdf "Exponential (blue) and sigmoid (purple) dynamical systems." height=4cm
+
+</em>
+
+\section dyn_sys_second_order_systems Second-Order Systems 
+
+The \b order of a dynamical system is the order of the highest derivative in the differential equation. For instance, \f$\dot{x} = -\alpha x\f$ is of order 1, because the derivative with the highest order (\f$\dot{x}\f$) has order 1. Such a system is known as a first-order system. All systems considered so far have been first-order systems, because the derivative with the highest order, i.e. \f$ \dot{x} \f$, has always been of order 1. 
+
+\subsection dyn_sys_spring_damper Spring-Damper Systems 
+
+An example of a second order system (which also has terms \f$ \ddot{x} \f$) is a spring-damper system (see http://en.wikipedia.org/wiki/Damped_spring-mass_system), where \f$k\f$ is the spring constant, \f$c\f$ is the damping coefficient, and \f$m\f$ is the mass:
+
+\f{eqnarray*}{
+m\ddot{x}=& -kx -c\dot{x}      & \mbox{spring-damper  (2nd order system)} \label{equ_}\\
+\ddot{x}=& (-kx -c\dot{x})/m   &
+\f}
+
+\subsection dyn_sys_critical_damping Critical Damping 
+
+A spring-damper system is called critically damped when it converges to the attractor as quickly as possible without overshooting, as the red plot in http://en.wikipedia.org/wiki/File:Damping_1.svg. This happens when \f$c = 2\sqrt{mk}\f$.
+
+
+\subsection dyn_sys_rewrite_second_first Rewriting one 2nd Order Systems as two 1st Order Systems
+
+For implementation purposes, it is more convenient to work only with 1st order systems. Fortunately, we can expand the state \f$ x \f$ into two components \f$ x = [y~z]^T\f$ with \f$ z = \dot{y}\f$, and rewrite the differential equation as follows:
+
+\f$
+\left[ \begin{array}{l} \dot{z} \\ \dot{y} \end{array} \right] = \left[ \begin{array}{l} (-ky -cz)/m \\ z \end{array} \right]
+\f$
+
+With this rewrite, the left term contains only first order derivatives, and the right term does not contain any derivatives. This is thus a first order system. Integrating such an expanded system is done just as one would integrate a dynamical system with a multi-dimensional state:
+
+\subsection Implementation
+<em>
+The constructor DynamicalSystem::DynamicalSystem immediately converts second order systems into first order systems with an expanded state.
+
+The function DynamicalSystem::dim() returns the size of the entire state vector \f$ x = [y~z]\f$, the function DynamicalSystem::dim_orig() return the size of only the \f$ y \f$ component. The attractor and initial state must always have the size returned by DynamicalSystem::dim_orig().
+</em>
+
+*/
+
+

--- a/src/dynamicalsystems/ExponentialSystem.cpp
+++ b/src/dynamicalsystems/ExponentialSystem.cpp
@@ -20,7 +20,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
  */
-
+#define EIGEN2_SUPPORT
 #include <boost/serialization/export.hpp>
 #include <boost/archive/text_iarchive.hpp>
 #include <boost/archive/text_oarchive.hpp>

--- a/src/dynamicalsystems/ExponentialSystem.cpp~
+++ b/src/dynamicalsystems/ExponentialSystem.cpp~
@@ -1,0 +1,116 @@
+/**
+ * @file   ExponentialSystem.cpp
+ * @brief  ExponentialSystem class source file.
+ * @author Freek Stulp
+ *
+ * This file is part of DmpBbo, a set of libraries and programs for the 
+ * black-box optimization of dynamical movement primitives.
+ * Copyright (C) 2014 Freek Stulp, ENSTA-ParisTech
+ * 
+ * DmpBbo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ * 
+ * DmpBbo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <boost/serialization/export.hpp>
+#include <boost/archive/text_iarchive.hpp>
+#include <boost/archive/text_oarchive.hpp>
+#include <boost/archive/xml_iarchive.hpp>
+#include <boost/archive/xml_oarchive.hpp>
+#include "dynamicalsystems/ExponentialSystem.hpp"
+
+BOOST_CLASS_EXPORT_IMPLEMENT(DmpBbo::ExponentialSystem);
+
+#include <boost/serialization/base_object.hpp>
+
+#include <cmath>
+#include <vector>
+#include <iostream>
+#include <eigen3/Eigen/Core>
+
+#include "dmpbbo_io/EigenBoostSerialization.hpp"
+#include "dmpbbo_io/BoostSerializationToString.hpp"
+
+
+using namespace std;
+using namespace Eigen;  
+
+namespace DmpBbo {
+    
+ExponentialSystem::ExponentialSystem(double tau, VectorXd y_init, VectorXd y_attr, double alpha, string name)
+  : DynamicalSystem(1, tau, y_init, y_attr, name),
+  alpha_(alpha)
+{
+}
+
+ExponentialSystem::~ExponentialSystem(void)
+{
+}
+
+DynamicalSystem* ExponentialSystem::clone(void) const
+{
+  return new ExponentialSystem(tau(),initial_state(),attractor_state(),alpha_,name());
+}
+
+
+void ExponentialSystem::differentialEquation(const VectorXd& x, Ref<VectorXd> xd) const
+{
+  xd = alpha_*(attractor_state()-x)/tau();
+}
+
+void ExponentialSystem::analyticalSolution(const VectorXd& ts, MatrixXd& xs, MatrixXd& xds) const
+{
+  int T = ts.size();
+  assert(T>0);
+
+  // Usually, we expect xs and xds to be of size T X dim(), so we resize to that. However, if the
+  // input matrices were of size dim() X T, we return the matrices of that size by doing a 
+  // transposeInPlace at the end. That way, the user can also request dim() X T sized matrices.
+  bool caller_expects_transposed = (xs.rows()==dim() && xs.cols()==T);
+
+  // Prepare output arguments to be of right size (Eigen does nothing if already the right size)
+  xs.resize(T,dim());
+  xds.resize(T,dim());
+  
+  VectorXd val_range = initial_state() - attractor_state();
+  
+  VectorXd exp_term  = -alpha_*ts/tau();
+  exp_term = exp_term.array().exp().transpose();
+  VectorXd pos_scale =                   exp_term;
+  VectorXd vel_scale = -(alpha_/tau()) * exp_term;
+  
+  xs = val_range.transpose().replicate(T,1).array() * pos_scale.replicate(1,dim()).array();
+  xs += attractor_state().transpose().replicate(T,1);
+  xds = val_range.transpose().replicate(T,1).array() * vel_scale.replicate(1,dim()).array();
+  
+  if (caller_expects_transposed)
+  {
+    xs.transposeInPlace();
+    xds.transposeInPlace();
+  }
+}
+
+template<class Archive>
+void ExponentialSystem::serialize(Archive & ar, const unsigned int version)
+{
+  // serialize base class information
+  ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(DynamicalSystem);
+
+  ar & BOOST_SERIALIZATION_NVP(alpha_);
+}
+
+string ExponentialSystem::toString(void) const
+{
+  RETURN_STRING_FROM_BOOST_SERIALIZATION_XML("ExponentialSystem");
+}
+
+}

--- a/src/dynamicalsystems/SigmoidSystem.cpp
+++ b/src/dynamicalsystems/SigmoidSystem.cpp
@@ -20,7 +20,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
  */
-
+#define EIGEN2_SUPPORT
 #include <boost/serialization/export.hpp>
 #include <boost/archive/text_iarchive.hpp>
 #include <boost/archive/text_oarchive.hpp>

--- a/src/dynamicalsystems/SigmoidSystem.cpp~
+++ b/src/dynamicalsystems/SigmoidSystem.cpp~
@@ -1,0 +1,155 @@
+/**
+ * @file   SigmoidSystem.cpp
+ * @brief  SigmoidSystem class source file.
+ * @author Freek Stulp
+ *
+ * This file is part of DmpBbo, a set of libraries and programs for the 
+ * black-box optimization of dynamical movement primitives.
+ * Copyright (C) 2014 Freek Stulp, ENSTA-ParisTech
+ * 
+ * DmpBbo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ * 
+ * DmpBbo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <boost/serialization/export.hpp>
+#include <boost/archive/text_iarchive.hpp>
+#include <boost/archive/text_oarchive.hpp>
+#include <boost/archive/xml_iarchive.hpp>
+#include <boost/archive/xml_oarchive.hpp>
+#include "dynamicalsystems/SigmoidSystem.hpp"
+
+BOOST_CLASS_EXPORT_IMPLEMENT(DmpBbo::SigmoidSystem);
+
+#include <cmath>
+#include <vector>
+#include <iostream>  
+#include <eigen3/Eigen/Core>
+
+#include "dmpbbo_io/EigenBoostSerialization.hpp"
+#include "dmpbbo_io/BoostSerializationToString.hpp"
+
+using namespace std;
+using namespace Eigen;
+
+namespace DmpBbo {
+
+SigmoidSystem::SigmoidSystem(double tau, const VectorXd& x_init, double max_rate, double inflection_point_time, string name)
+: DynamicalSystem(1, tau, x_init, VectorXd::Zero(x_init.size()), name),
+  max_rate_(max_rate),
+  inflection_point_time_(inflection_point_time)
+{
+  Ks_ = SigmoidSystem::computeKs(initial_state(), max_rate_, inflection_point_time_);
+}
+
+SigmoidSystem::~SigmoidSystem(void)
+{
+}
+
+DynamicalSystem* SigmoidSystem::clone(void) const
+{
+  return new SigmoidSystem(tau(),initial_state(),max_rate_,inflection_point_time_,name());
+}
+
+void SigmoidSystem::set_tau(double new_tau) {
+
+  // Get previous tau from superclass with tau() and set it with set_tau()  
+  double prev_tau = tau();
+  DynamicalSystem::set_tau(new_tau);
+  
+  inflection_point_time_ = new_tau*inflection_point_time_/prev_tau; // todo document this
+  Ks_ = SigmoidSystem::computeKs(initial_state(), max_rate_, inflection_point_time_);
+}
+
+void SigmoidSystem::set_initial_state(const VectorXd& y_init) {
+  assert(y_init.size()==dim_orig());
+  DynamicalSystem::set_initial_state(y_init);
+  Ks_ = SigmoidSystem::computeKs(initial_state(), max_rate_, inflection_point_time_);
+}    
+
+VectorXd SigmoidSystem::computeKs(const VectorXd& N_0s, double r, double inflection_point_time_time)
+{
+  // Known
+  //   N(t) = K / ( 1 + (K/N_0 - 1)*exp(-r*t))
+  //   N(t_inf) = K / 2
+  // Plug into each other and solve for K
+  //   K / ( 1 + (K/N_0 - 1)*exp(-r*t_infl)) = K/2
+  //              (K/N_0 - 1)*exp(-r*t_infl) = 1
+  //                             (K/N_0 - 1) = 1/exp(-r*t_infl)
+  //                                       K = N_0*(1+(1/exp(-r*t_infl)))
+  VectorXd Ks = N_0s;
+  for (int dd=0; dd<Ks.size(); dd++)
+    Ks[dd] = N_0s[dd]*(1+(1/exp(-r*inflection_point_time_time)));
+  return Ks;
+}
+
+void SigmoidSystem::differentialEquation(const VectorXd& x, Ref<VectorXd> xd) const
+{
+  xd = max_rate_*x.array()*(1-(x.array()/Ks_.array()));
+}
+
+void SigmoidSystem::analyticalSolution(const VectorXd& ts, MatrixXd& xs, MatrixXd& xds) const
+{
+  int T = ts.size();
+  assert(T>0);
+
+  // Usually, we expect xs and xds to be of size T X dim(), so we resize to that. However, if the
+  // input matrices were of size dim() X T, we return the matrices of that size by doing a 
+  // transposeInPlace at the end. That way, the user can also request dim() X T sized matrices.
+  bool caller_expects_transposed = (xs.rows()==dim() && xs.cols()==T);
+
+  // Prepare output arguments to be of right size (Eigen does nothing if already the right size)
+  xs.resize(T,dim());
+  xds.resize(T,dim());
+
+  // Auxillary variables to improve legibility
+  double r = max_rate_;
+  VectorXd exp_rt = (-r*ts).array().exp();
+  
+  VectorXd y_init = initial_state();
+      
+  for (int dd=0; dd<dim(); dd++)
+  {
+    // Auxillary variables to improve legibility
+    double K = Ks_[dd];
+    double b = (K/y_init[dd])-1;
+        
+    xs.block(0,dd,T,1)  = K/(1+b*exp_rt.array());
+    xds.block(0,dd,T,1) = K*r*b*((1 + b*exp_rt.array()).square().inverse().array()) * exp_rt.array();
+  }
+  
+  if (caller_expects_transposed)
+  {
+    xs.transposeInPlace();
+    xds.transposeInPlace();
+  }
+}
+
+template<class Archive>
+void SigmoidSystem::serialize(Archive & ar, const unsigned int version)
+{
+  // serialize base class information
+  ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(DynamicalSystem);
+
+  ar & BOOST_SERIALIZATION_NVP(max_rate_);
+  ar & BOOST_SERIALIZATION_NVP(inflection_point_time_);
+  ar & BOOST_SERIALIZATION_NVP(Ks_);
+}
+
+  
+string SigmoidSystem::toString(void) const
+{
+  RETURN_STRING_FROM_BOOST_SERIALIZATION_XML("SigmoidSystem");
+}
+
+}
+

--- a/src/dynamicalsystems/SigmoidSystem.hpp
+++ b/src/dynamicalsystems/SigmoidSystem.hpp
@@ -3,20 +3,20 @@
  * @brief  SigmoidSystem class header file.
  * @author Freek Stulp
  *
- * This file is part of DmpBbo, a set of libraries and programs for the 
+ * This file is part of DmpBbo, a set of libraries and programs for the
  * black-box optimization of dynamical movement primitives.
  * Copyright (C) 2014 Freek Stulp, ENSTA-ParisTech
- * 
+ *
  * DmpBbo is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 2 of the License, or
  * (at your option) any later version.
- * 
+ *
  * DmpBbo is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU Lesser General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU Lesser General Public License
  * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -45,38 +45,47 @@ public:
    *  \param name             Name for the sytem,           cf. DynamicalSystem::name()
    */
    SigmoidSystem(double tau, const Eigen::VectorXd& x_init, double max_rate, double inflection_point_time, std::string name="SigmoidSystem");
-  
+
   /** Destructor. */
   ~SigmoidSystem(void);
 
   DynamicalSystem* clone(void) const;
 
   void differentialEquation(const Eigen::VectorXd& x, Eigen::Ref<Eigen::VectorXd> xd) const;
- 
+
   void analyticalSolution(const Eigen::VectorXd& ts, Eigen::MatrixXd& xs, Eigen::MatrixXd& xds) const;
 
   void set_tau(double tau);
   void set_initial_state(const Eigen::VectorXd& y_init);
 
+  /// ----------------------------------------------------------------------------
+  void printVariables(void);
+  /// ----------------------------------------------------------------------------
+
 	std::string toString(void) const;
 
 private:
   static Eigen::VectorXd computeKs(const Eigen::VectorXd& N_0s, double r, double inflection_point_time_time);
-  
+
   double max_rate_;
   double inflection_point_time_;
   Eigen::VectorXd Ks_;
-  
+
+  /// ----------------------------------------------------------------------------
+    double _prev_tau;
+    double _new_tau;
+  /// ----------------------------------------------------------------------------
+
   /**
    * Default constructor.
    * \remarks This default constuctor is required for boost::serialization to work. See \ref sec_boost_serialization_ugliness
    */
   SigmoidSystem(void) {};
-  
-  /** Give boost serialization access to private members. */  
+
+  /** Give boost serialization access to private members. */
   friend class boost::serialization::access;
-  
-  /** Serialize class data members to boost archive. 
+
+  /** Serialize class data members to boost archive.
    * \param[in] ar Boost archive
    * \param[in] version Version of the class
    * See http://www.boost.org/doc/libs/1_55_0/libs/serialization/doc/tutorial.html#simplecase

--- a/src/dynamicalsystems/SigmoidSystem.hpp
+++ b/src/dynamicalsystems/SigmoidSystem.hpp
@@ -58,23 +58,13 @@ public:
   void set_tau(double tau);
   void set_initial_state(const Eigen::VectorXd& y_init);
 
-  /// ----------------------------------------------------------------------------
-  void printVariables(void);
-  /// ----------------------------------------------------------------------------
-
 	std::string toString(void) const;
 
 private:
-  static Eigen::VectorXd computeKs(const Eigen::VectorXd& N_0s, double r, double inflection_point_time_time);
 
   double max_rate_;
   double inflection_point_time_;
-  Eigen::VectorXd Ks_;
 
-  /// ----------------------------------------------------------------------------
-    double _prev_tau;
-    double _new_tau;
-  /// ----------------------------------------------------------------------------
 
   /**
    * Default constructor.

--- a/src/dynamicalsystems/SigmoidSystem.hpp
+++ b/src/dynamicalsystems/SigmoidSystem.hpp
@@ -64,7 +64,7 @@ private:
 
   double max_rate_;
   double inflection_point_time_;
-
+  Eigen::VectorXd K_;
 
   /**
    * Default constructor.

--- a/src/dynamicalsystems/SigmoidSystem.hpp
+++ b/src/dynamicalsystems/SigmoidSystem.hpp
@@ -57,6 +57,7 @@ public:
 
   void set_tau(double tau);
   void set_initial_state(const Eigen::VectorXd& y_init);
+  void initializeSystem(double tau_tmp);
 
 	std::string toString(void) const;
 

--- a/src/dynamicalsystems/SpringDamperSystem.cpp
+++ b/src/dynamicalsystems/SpringDamperSystem.cpp
@@ -21,7 +21,7 @@
  * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
  */
  
-
+#define EIGEN2_SUPPORT
 #include <boost/serialization/export.hpp>
 #include <boost/archive/text_iarchive.hpp>
 #include <boost/archive/text_oarchive.hpp>

--- a/src/dynamicalsystems/SpringDamperSystem.cpp~
+++ b/src/dynamicalsystems/SpringDamperSystem.cpp~
@@ -1,0 +1,180 @@
+/**
+ * @file   SpringDamperSystem.cpp
+ * @brief  SpringDamperSystem class source file.
+ * @author Freek Stulp
+ *
+ * This file is part of DmpBbo, a set of libraries and programs for the 
+ * black-box optimization of dynamical movement primitives.
+ * Copyright (C) 2014 Freek Stulp, ENSTA-ParisTech
+ * 
+ * DmpBbo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ * 
+ * DmpBbo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
+
+#include <boost/serialization/export.hpp>
+#include <boost/archive/text_iarchive.hpp>
+#include <boost/archive/text_oarchive.hpp>
+#include <boost/archive/xml_iarchive.hpp>
+#include <boost/archive/xml_oarchive.hpp>
+#include "dynamicalsystems/SpringDamperSystem.hpp"
+
+BOOST_CLASS_EXPORT_IMPLEMENT(DmpBbo::SpringDamperSystem);
+
+#include <cmath>
+#include <iostream>
+#include <eigen3/Eigen/Core>
+
+#include "dmpbbo_io/EigenBoostSerialization.hpp"
+#include "dmpbbo_io/BoostSerializationToString.hpp"
+
+using namespace std;
+using namespace Eigen;
+
+namespace DmpBbo {
+
+SpringDamperSystem::SpringDamperSystem(double tau, VectorXd y_init, VectorXd y_attr, double damping_coefficient, double spring_constant, double mass, string name)
+  : DynamicalSystem(2, tau, y_init, y_attr, name),
+  damping_coefficient_(damping_coefficient),spring_constant_(spring_constant),mass_(mass)
+{
+  if (spring_constant_==CRITICALLY_DAMPED)
+    spring_constant_ = damping_coefficient_*damping_coefficient_/4; // Critically damped
+}
+
+SpringDamperSystem::~SpringDamperSystem(void)
+{
+}
+
+DynamicalSystem* SpringDamperSystem::clone(void) const
+{
+  return new SpringDamperSystem(tau(),initial_state(),attractor_state(),
+                        damping_coefficient_,spring_constant_,mass_,name());
+}
+
+void SpringDamperSystem::differentialEquation(const VectorXd& x, Ref<VectorXd> xd) const
+{
+  // Spring-damper system was originally 2nd order, i.e. with [x xd xdd]
+  // After rewriting it as a 1st order system it becomes [y z yd zd], with yd = z; 
+      
+  // Get 'y' and 'z' parts of the state in 'x'
+  int dim2 = dim()/2;
+  VectorXd y = x.segment(0,dim2);
+  VectorXd z = x.segment(dim2,dim2);
+  VectorXd y_attr = attractor_state().segment(0,dim2);
+  
+  // Compute yd and zd
+  // See  http://en.wikipedia.org/wiki/Damped_spring-mass_system#Example:mass_.E2.80.93spring.E2.80.93damper
+  // and equation 2.1 of http://www-clmc.usc.edu/publications/I/ijspeert-NC2013.pdf
+
+  VectorXd yd = z/tau();
+  
+  VectorXd zd = (-spring_constant_*(y-y_attr) - damping_coefficient_*z)/(mass_*tau());
+  
+  xd.segment(0,dim()/2) = yd;
+  xd.segment(dim()/2,dim()/2) = zd;
+      
+}
+
+void SpringDamperSystem::analyticalSolution(const VectorXd& ts, MatrixXd& xs, MatrixXd& xds) const
+{
+  int T = ts.size();
+  assert(T>0);
+
+  // Usually, we expect xs and xds to be of size T X dim(), so we resize to that. However, if the
+  // input matrices were of size dim() X T, we return the matrices of that size by doing a 
+  // transposeInPlace at the end. That way, the user can also request dim() X T sized matrices.
+  bool caller_expects_transposed = (xs.rows()==dim() && xs.cols()==T);
+
+  // Prepare output arguments to be of right size (Eigen does nothing if already the right size)
+  xs.resize(T,dim());
+  xds.resize(T,dim());
+
+  VectorXd y_init = initial_state();
+  VectorXd y_attr = attractor_state();
+  
+  // Closed form solution to 2nd order canonical system
+  // This system behaves like a critically damped spring-damper system
+  // http://en.wikipedia.org/wiki/Damped_spring-mass_system
+  double omega_0 = sqrt(spring_constant_/mass_)/tau(); // natural frequency
+  double zeta    = damping_coefficient_/(2*sqrt(mass_*spring_constant_)); // damping ratio
+  if (zeta!=1.0)
+    cout << "WARNING: Spring-damper system is not critically damped, zeta=" << zeta << endl;
+      
+  // Example
+  //  _______________
+  //    dim = 4
+  //  _______
+  //  dim2= 2
+  // [y_1 y_2 z_1 z_2 yd_1 yd_2 zd_1 zd_2]
+  
+  int dim2 = dim()/2;
+
+  // The loop is slower, but more legible than fudging around with Eigen::replicate().
+  for (int i_dim=0; i_dim<dim2; i_dim++)
+  {
+    double y0 = y_init[i_dim] - y_attr[i_dim];
+    double yd0;
+    if (y_init.size()>=dim())
+    {
+      // Initial velocities also given
+      yd0 = y_init[dim2 + i_dim];          
+    }
+    else
+    {
+      // Initial velocities not given: set to zero
+      yd0 = 0.0;
+    }
+          
+    double A = y0;
+    double B = yd0 + omega_0*y0;
+    
+    // Closed form solutions
+    // See http://en.wikipedia.org/wiki/Damped_spring-mass_system
+    VectorXd exp_term  = -omega_0*ts;
+    exp_term = exp_term.array().exp();
+  
+    int Y  = 0*dim2 + i_dim;
+    int Z  = 1*dim2 + i_dim;
+   
+    VectorXd ABts = A + B*ts.array();
+    
+    // Closed form solutions
+    // See http://en.wikipedia.org/wiki/Damped_spring-mass_system
+    // If you find this illegible, I recommend to look at the Matlab code instead...
+    xs.col(Y)  =  y_attr(i_dim) +      ((   ABts.array()))*exp_term.array();
+                                                    
+    // Derivative of the above (use product rule: (f*g)' = f'*g + f*g'
+    xds.col(Y) =                    ((B - omega_0*   ABts.array()))*exp_term.array();
+                                                    
+    // Derivative of the above (again use product    rule: (f*g)' = f'*g + f*g'
+    VectorXd ydds   =    (-omega_0*(2*B - omega_0*   ABts.array()))*exp_term.array();
+      
+    // This is how to compute the 'z' terms from the 'y' terms
+    xs.col(Z)  = xds.col(Y)*tau();
+    xds.col(Z) = ydds*tau();
+  }
+        
+  if (caller_expects_transposed)
+  {
+    xs.transposeInPlace();
+    xds.transposeInPlace();
+  }
+}
+
+string SpringDamperSystem::toString(void) const
+{
+  RETURN_STRING_FROM_BOOST_SERIALIZATION_XML("SpringDamperSystem");
+}
+
+
+}

--- a/src/dynamicalsystems/TimeSystem.cpp
+++ b/src/dynamicalsystems/TimeSystem.cpp
@@ -20,7 +20,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
  */
-
+#define EIGEN2_SUPPORT
 #include <boost/serialization/export.hpp>
 #include <boost/archive/text_iarchive.hpp>
 #include <boost/archive/text_oarchive.hpp>

--- a/src/dynamicalsystems/TimeSystem.cpp~
+++ b/src/dynamicalsystems/TimeSystem.cpp~
@@ -1,0 +1,145 @@
+/**
+ * @file   TimeSystem.cpp
+ * @brief  TimeSystem class source file.
+ * @author Freek Stulp
+ *
+ * This file is part of DmpBbo, a set of libraries and programs for the 
+ * black-box optimization of dynamical movement primitives.
+ * Copyright (C) 2014 Freek Stulp, ENSTA-ParisTech
+ * 
+ * DmpBbo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ * 
+ * DmpBbo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <boost/serialization/export.hpp>
+#include <boost/archive/text_iarchive.hpp>
+#include <boost/archive/text_oarchive.hpp>
+#include <boost/archive/xml_iarchive.hpp>
+#include <boost/archive/xml_oarchive.hpp>
+#include "dynamicalsystems/TimeSystem.hpp"
+
+BOOST_CLASS_EXPORT_IMPLEMENT(DmpBbo::TimeSystem);
+
+#include <cmath>
+#include <vector>
+#include <iostream>
+#include <eigen3/Eigen/Core>
+
+#include "dmpbbo_io/BoostSerializationToString.hpp"
+
+using namespace std;
+using namespace Eigen;
+
+namespace DmpBbo {
+
+TimeSystem::TimeSystem(double tau, bool count_down, string name)
+: 
+  DynamicalSystem(1, tau, VectorXd::Zero(1), VectorXd::Ones(1), name),
+  count_down_(count_down)
+{
+  if (count_down_)
+  {
+    set_initial_state(VectorXd::Ones(1));
+    set_attractor_state(VectorXd::Zero(1));
+  }
+}
+
+TimeSystem::~TimeSystem(void)
+{
+}
+
+DynamicalSystem* TimeSystem::clone(void) const
+{
+  return new TimeSystem(tau(),count_down(),name());
+}
+
+void TimeSystem::differentialEquation(const VectorXd& x, Ref<VectorXd> xd) const
+{
+  // if state<1: xd = 1/obj.tau   (or for count_down=true, if state>0: xd = -1/obj.tau
+  // else        xd = 0
+  xd = VectorXd::Zero(1);
+  if (count_down_)
+  {
+    if (x[0]>0)
+      xd[0] = -1.0/tau();
+  }
+  else
+  {
+    if (x[0]<1)
+      xd[0] = 1.0/tau();
+  }
+}
+
+void TimeSystem::analyticalSolution(const VectorXd& ts, MatrixXd& xs, MatrixXd& xds) const
+{
+  int T = ts.size();
+  assert(T>0);
+
+  // Usually, we expect xs and xds to be of size T X dim(), so we resize to that. However, if the
+  // input matrices were of size dim() X T, we return the matrices of that size by doing a 
+  // transposeInPlace at the end. That way, the user can also request dim() X T sized matrices.
+  bool caller_expects_transposed = (xs.rows()==dim() && xs.cols()==T);
+
+  // Prepare output arguments to be of right size (Eigen does nothing if already the right size)
+  xs.resize(T,dim());
+  xds.resize(T,dim());
+  
+  // Find first index at which the time is larger than tau. Then velocities should be set to zero.
+  int velocity_stop_index = -1;
+  int i=0;
+  while (velocity_stop_index<0 && i<ts.size())
+    if (ts[i++]>tau())
+      velocity_stop_index = i-1;
+    
+  if (velocity_stop_index<0)
+    velocity_stop_index = ts.size();
+
+  if (count_down_)
+  {
+    xs.topRows(velocity_stop_index) = (-ts.segment(0,velocity_stop_index).array()/tau()).array()+1.0;
+    xs.bottomRows(xs.size()-velocity_stop_index).fill(0.0);
+  
+    xds.topRows(velocity_stop_index).fill(-1.0/tau());
+    xds.bottomRows(xds.size()-velocity_stop_index).fill(0.0);
+  }
+  else
+  {
+    xs.topRows(velocity_stop_index) = ts.segment(0,velocity_stop_index).array()/tau();
+    xs.bottomRows(xs.size()-velocity_stop_index).fill(1.0);
+  
+    xds.topRows(velocity_stop_index).fill(1.0/tau());
+    xds.bottomRows(xds.size()-velocity_stop_index).fill(0.0);
+  }
+  
+  if (caller_expects_transposed)
+  {
+    xs.transposeInPlace();
+    xds.transposeInPlace();
+  }
+}
+
+template<class Archive>
+void TimeSystem::serialize(Archive & ar, const unsigned int version)
+{
+  // serialize base class information
+  ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(DynamicalSystem);
+  
+  ar & BOOST_SERIALIZATION_NVP(count_down_);
+}
+
+string TimeSystem::toString(void) const
+{
+  RETURN_STRING_FROM_BOOST_SERIALIZATION_XML("TimeSystem");
+}
+
+}

--- a/src/functionapproximators/FunctionApproximator.cpp
+++ b/src/functionapproximators/FunctionApproximator.cpp
@@ -20,7 +20,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
  */
-
+#define EIGEN2_SUPPORT
 #include "functionapproximators/FunctionApproximator.hpp"
 
 #include "functionapproximators/ModelParameters.hpp"

--- a/src/functionapproximators/FunctionApproximator.cpp~
+++ b/src/functionapproximators/FunctionApproximator.cpp~
@@ -1,0 +1,301 @@
+/**
+ * @file   FunctionApproximator.cpp
+ * @brief  FunctionApproximator class source file.
+ * @author Freek Stulp
+ *
+ * This file is part of DmpBbo, a set of libraries and programs for the 
+ * black-box optimization of dynamical movement primitives.
+ * Copyright (C) 2014 Freek Stulp, ENSTA-ParisTech
+ * 
+ * DmpBbo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ * 
+ * DmpBbo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "functionapproximators/FunctionApproximator.hpp"
+
+#include "functionapproximators/ModelParameters.hpp"
+#include "functionapproximators/MetaParameters.hpp"
+
+#include "dmpbbo_io/EigenFileIO.hpp"
+#include "dmpbbo_io/EigenBoostSerialization.hpp"
+#include "dmpbbo_io/BoostSerializationToString.hpp"
+
+#include <iostream>
+#include <fstream>
+#include <eigen3/Eigen/Core>
+#include <boost/filesystem.hpp> // Required only for train(inputs,outputs,save_directory)
+
+using namespace std;
+using namespace Eigen;
+
+
+/** \defgroup FunctionApproximators Function Approximators
+ */
+
+namespace DmpBbo { 
+
+/******************************************************************************/
+FunctionApproximator::FunctionApproximator(MetaParameters *meta_parameters, ModelParameters *model_parameters) 
+{
+  assert(meta_parameters!=NULL);
+  
+  meta_parameters_  = meta_parameters->clone();
+  if (model_parameters!=NULL)
+  {
+    model_parameters_ = model_parameters->clone();
+    assert(model_parameters_->getExpectedInputDim()==meta_parameters_->getExpectedInputDim());
+  }
+  else
+  {
+    model_parameters_ = NULL;
+  }
+
+}
+
+FunctionApproximator::FunctionApproximator(ModelParameters *model_parameters) 
+{
+  assert(model_parameters!=NULL);
+  meta_parameters_  = NULL;
+  model_parameters_ = model_parameters->clone();
+}
+
+FunctionApproximator::~FunctionApproximator(void) 
+{
+  delete meta_parameters_;
+  delete model_parameters_;
+}
+
+
+/******************************************************************************/
+const MetaParameters* FunctionApproximator::getMetaParameters(void) const 
+{ 
+  return meta_parameters_; 
+};
+  
+/******************************************************************************/
+const ModelParameters* FunctionApproximator::getModelParameters(void) const 
+{ 
+  return model_parameters_; 
+};
+
+/******************************************************************************/
+void FunctionApproximator::setModelParameters(ModelParameters* model_parameters)
+{
+  if (model_parameters_!=NULL)
+  {
+    delete model_parameters_;
+    model_parameters_ = NULL;
+  }
+
+  model_parameters_ = model_parameters;
+}
+
+int FunctionApproximator::getExpectedInputDim(void) const
+{
+  if (model_parameters_!=NULL)
+    return model_parameters_->getExpectedInputDim();
+  else
+    return meta_parameters_->getExpectedInputDim();
+}
+
+void FunctionApproximator::reTrain(const MatrixXd& inputs, const MatrixXd& targets)
+{
+  delete model_parameters_;
+  model_parameters_ = NULL;
+  train(inputs,targets);
+}
+
+void FunctionApproximator::reTrain(const MatrixXd& inputs, const MatrixXd& targets, string save_directory, bool overwrite)
+{
+  delete model_parameters_;
+  model_parameters_ = NULL;
+  train(inputs,targets,save_directory,overwrite);
+}
+
+
+void FunctionApproximator::getParameterVectorSelectedMinMax(VectorXd& min, VectorXd& max) const
+{
+  if (model_parameters_==NULL)
+  {
+    cerr << __FILE__ << ":" << __LINE__ << ": Warning: Trying to access model parameters of the function approximator, but it has not been trained yet. Returning empty parameter vector." << endl;
+    min.resize(0);
+    max.resize(0);
+    return;
+  }
+
+  model_parameters_->getParameterVectorSelectedMinMax(min,max);
+}
+
+/******************************************************************************/
+bool FunctionApproximator::checkModelParametersInitialized(void) const
+{
+  if (model_parameters_==NULL)
+  {
+    cerr << "Warning: Trying to access model parameters of the function approximator, but it has not been trained yet. Returning empty parameter vector." << endl;
+    return false;
+  }
+  return true;
+  
+}
+
+/******************************************************************************/
+void FunctionApproximator::getParameterVectorSelected(VectorXd& values, bool normalized) const
+{
+  if (checkModelParametersInitialized())
+    model_parameters_->getParameterVectorSelected(values, normalized);
+  else
+    values.resize(0);
+}
+
+/******************************************************************************/
+int FunctionApproximator::getParameterVectorSelectedSize(void) const
+{
+  if (checkModelParametersInitialized())
+    return model_parameters_->getParameterVectorSelectedSize();
+  else 
+    return 0; 
+}
+
+void FunctionApproximator::setParameterVectorSelected(const VectorXd& values, bool normalized) 
+{
+  if (checkModelParametersInitialized())
+    model_parameters_->setParameterVectorSelected(values, normalized);
+}
+
+void FunctionApproximator::setSelectedParameters(const set<string>& selected_values_labels)
+{
+  if (checkModelParametersInitialized())
+    model_parameters_->setSelectedParameters(selected_values_labels);
+}
+
+void FunctionApproximator::getSelectableParameters(set<string>& labels) const
+{
+  if (checkModelParametersInitialized())
+    model_parameters_->getSelectableParameters(labels);
+  else
+    labels.clear();
+}
+
+void FunctionApproximator::getParameterVectorMask(const std::set<std::string> selected_values_labels, Eigen::VectorXi& selected_mask) const {
+  if (checkModelParametersInitialized())
+    model_parameters_->getParameterVectorMask(selected_values_labels,selected_mask);
+  else
+    selected_mask.resize(0);
+  
+};
+int FunctionApproximator::getParameterVectorAllSize(void) const {
+  if (checkModelParametersInitialized())
+    return model_parameters_->getParameterVectorAllSize();
+  else
+    return 0;
+};
+void FunctionApproximator::getParameterVectorAll(Eigen::VectorXd& values) const {
+  if (checkModelParametersInitialized())
+    model_parameters_->getParameterVectorAll(values);    
+  else
+    values.resize(0);
+};
+void FunctionApproximator::setParameterVectorAll(const Eigen::VectorXd& values) {
+  if (checkModelParametersInitialized())
+    model_parameters_->setParameterVectorAll(values);
+};
+
+string FunctionApproximator::toString(void) const
+{
+  string name = "FunctionApproximator"+getName();
+  RETURN_STRING_FROM_BOOST_SERIALIZATION_XML(name.c_str());
+}
+
+
+void FunctionApproximator::train(const MatrixXd& inputs, const MatrixXd& targets, string save_directory, bool overwrite)
+{
+  train(inputs,targets);
+  
+  if (save_directory.empty())
+    return;
+  
+  if (!isTrained())
+    return;
+  
+  if (getExpectedInputDim()<3)
+  {
+    
+    VectorXd min = inputs.colwise().minCoeff();
+    VectorXd max = inputs.colwise().maxCoeff();
+    
+    int n_samples_per_dim = 100;
+    if (getExpectedInputDim()==2) n_samples_per_dim = 40;
+    VectorXi n_samples_per_dim_vec = VectorXi::Constant(getExpectedInputDim(),n_samples_per_dim);
+
+    model_parameters_->saveGridData(min, max, n_samples_per_dim_vec, save_directory, overwrite);
+    
+  }
+
+  MatrixXd outputs;
+  predict(inputs,outputs);
+
+  saveMatrix(save_directory,"inputs.txt",inputs,overwrite);
+  saveMatrix(save_directory,"targets.txt",targets,overwrite);
+  saveMatrix(save_directory,"outputs.txt",outputs,overwrite);
+  
+  string filename = save_directory+"/plotdata.py";
+  ofstream outfile;
+  outfile.open(filename.c_str()); 
+  if (!outfile.is_open())
+  {
+    cerr << __FILE__ << ":" << __LINE__ << ":";
+    cerr << "Could not open file " << filename << " for writing." << endl;
+  } 
+  else
+  {
+    // Python code generation in C++. Rock 'n' roll! ;-)
+    if (inputs.cols()==2) {                                                                                           
+      outfile << "from mpl_toolkits.mplot3d import Axes3D                                       \n";
+    }
+    outfile   << "import numpy                                                                  \n";
+    outfile   << "import matplotlib.pyplot as plt                                               \n";
+    outfile   << "directory = '" << save_directory << "'                                        \n";
+    outfile   << "inputs   = numpy.loadtxt(directory+'/inputs.txt')                             \n";
+    outfile   << "targets  = numpy.loadtxt(directory+'/targets.txt')                            \n";
+    outfile   << "outputs  = numpy.loadtxt(directory+'/outputs.txt')                            \n";
+    outfile   << "fig = plt.figure()                                                            \n";
+    if (inputs.cols()==2) {                                                                                           
+      outfile << "ax = Axes3D(fig)                                                              \n";
+      outfile << "ax.plot(inputs[:,0],inputs[:,1],targets, '.', label='targets',color='black')  \n";
+      outfile << "ax.plot(inputs[:,0],inputs[:,1],outputs, '.', label='predictions',color='red')\n";
+      outfile << "ax.set_xlabel('input_1'); ax.set_ylabel('input_2'); ax.set_zlabel('output')   \n";
+      outfile << "ax.legend(loc='lower right')                                                  \n";
+    } else {                                                                                           
+      outfile << "plt.plot(inputs,targets, '.', label='targets',color='black')                  \n";
+      outfile << "plt.plot(inputs,outputs, '.', label='predictions',color='red')                \n";
+      outfile << "plt.xlabel('input'); plt.ylabel('output');                                    \n";
+      outfile << "plt.legend(loc='lower right')                                                 \n";
+    }                                                                                           
+    outfile   << "plt.show()                                                                    \n";
+    outfile << endl;
+
+    outfile.close();
+    //cout << "        ______________________________________________________________" << endl;
+    //cout << "        | Plot saved data with:" << " 'python " << filename << "'." << endl;
+    //cout << "        |______________________________________________________________" << endl;
+  }
+  
+}
+
+void FunctionApproximator::setParameterVectorModifierPrivate(std::string modifier, bool new_value)
+{
+  model_parameters_->setParameterVectorModifier(modifier,new_value);
+}
+
+}
+

--- a/src/functionapproximators/FunctionApproximator.hpp
+++ b/src/functionapproximators/FunctionApproximator.hpp
@@ -26,7 +26,7 @@
 
 #ifndef _FUNCTIONAPPROXIMATOR_H_
 #define _FUNCTIONAPPROXIMATOR_H_
-
+#define EIGEN2_SUPPORT
 #include "Parameterizable.hpp"
 
 #include <boost/serialization/nvp.hpp>

--- a/src/functionapproximators/FunctionApproximator.hpp~
+++ b/src/functionapproximators/FunctionApproximator.hpp~
@@ -1,0 +1,308 @@
+/**
+ * @file   FunctionApproximator.hpp
+ * @brief  FunctionApproximator class header file.
+ * @author Freek Stulp
+ *
+ * This file is part of DmpBbo, a set of libraries and programs for the 
+ * black-box optimization of dynamical movement primitives.
+ * Copyright (C) 2014 Freek Stulp, ENSTA-ParisTech
+ * 
+ * DmpBbo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ * 
+ * DmpBbo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/** \defgroup FunctionApproximators Function Approximators
+ */
+
+#ifndef _FUNCTIONAPPROXIMATOR_H_
+#define _FUNCTIONAPPROXIMATOR_H_
+
+#include "Parameterizable.hpp"
+
+#include <boost/serialization/nvp.hpp>
+
+#include <string>
+#include <vector>
+#include <eigen3/Eigen/Core>
+
+namespace DmpBbo {
+  
+// Forward declarations
+class MetaParameters;
+class ModelParameters;
+
+/** \brief Base class for all function approximators.
+ *  \ingroup FunctionApproximators
+ */
+class FunctionApproximator : public Parameterizable
+{
+
+public:
+  
+  /** Initialize a function approximator with meta- and optionally model-parameters
+   *  \param[in] meta_parameters  The training algorithm meta-parameters
+   *  \param[in] model_parameters The parameters of the trained model. If this parameter is not
+   *                              passed, the function approximator is initialized as untrained. 
+   *                              In this case, you must call FunctionApproximator::train() before
+   *                              being able to call FunctionApproximator::predict().
+   */
+  FunctionApproximator(MetaParameters *meta_parameters, ModelParameters *model_parameters=NULL);
+  
+  /** Initialize a function approximator with model-parameters
+   *  \param[in] model_parameters The parameters of the trained model.
+   */
+  FunctionApproximator(ModelParameters *model_parameters);
+
+  virtual ~FunctionApproximator(void);
+  
+  /** Return a pointer to a deep copy of the FunctionApproximator object.
+   *  \return Pointer to a deep copy
+   */
+  virtual FunctionApproximator* clone(void) const = 0;
+  
+  /** Train the function approximator with corresponding input and target examples.
+   *  \param[in] inputs  Input values of the training examples
+   *  \param[in] targets Target values of the training examples
+   */
+  virtual void train(const Eigen::MatrixXd& inputs, const Eigen::MatrixXd& targets) = 0;
+  
+  /** Train the function approximator with corresponding input and target examples (and write results to file).
+   *  \param[in] inputs  Input values of the training examples
+   *  \param[in] targets Target values of the training examples
+   *  \param[in] save_directory Directory to which to write results.
+   * \param[in] overwrite Whether to overwrite existing files. true=do overwrite, false=don't overwrite and give a warning.
+   */
+  void train(const Eigen::MatrixXd& inputs, const Eigen::MatrixXd& targets, std::string save_directory, bool overwrite=false);
+
+  /** Re-train the function approximator with corresponding input and target examples.
+   *  \param[in] inputs  Input values of the training examples
+   *  \param[in] targets Target values of the training examples
+   *  Re-training could in principle have been enabled through FunctionApproximator::train, but we
+   *  wanted to keep a clear disctinction between training (which must be done at least once before 
+   *  FunctionApproximator::predict) can be called and re-training.
+   */
+  void reTrain(const Eigen::MatrixXd& inputs, const Eigen::MatrixXd& targets);
+  
+  /** Re-train the function approximator with corresponding input and target examples (and write results to file).
+   *  \param[in] inputs  Input values of the training examples
+   *  \param[in] targets Target values of the training examples
+   *  \param[in] save_directory Directory to which to write results.
+   * \param[in] overwrite Overwrite existing files in the directory above (default: false)
+   *  Re-training could in principle have been enabled through FunctionApproximator::train, but we
+   *  wanted to keep a clear disctinction between training (which must be done at least once before 
+   *  FunctionApproximator::predict) can be called and re-training.
+   */
+  void reTrain(const Eigen::MatrixXd& inputs, const Eigen::MatrixXd& targets, std::string save_directory, bool overwrite=false);
+  
+  /** Query the function approximator to make a prediction
+   *  \param[in]  inputs   Input values of the query
+   *  \param[out] outputs  Predicted output values
+   *
+   * \remark This method should be const. But third party functions which is called in this function
+   * have not always been implemented as const (Examples: LWPRObject::predict or IRFRLS::predict ).
+   * Therefore, this function cannot be const.
+   */
+  virtual void predict(const Eigen::MatrixXd& inputs, Eigen::MatrixXd& outputs) = 0;
+  
+  /** Determine whether the function approximator has already been trained with data or not.
+   *  \return true if the function approximator has already been trained, false otherwise.
+   */
+  bool isTrained(void) const
+  {
+    return (model_parameters_!=NULL);
+  }
+  
+  /** The expected dimensionality of the input data.
+   * \return Expected dimensionality of the input data
+   */
+  int getExpectedInputDim(void) const;
+  
+  /** The expected dimensionality of the output data.
+   * For now, we only consider 1-dimensional output.
+   * \return Expected dimensionality of the output data
+   */
+  int getOutputDim(void) const 
+  {
+    return 1;
+  }
+  
+  /** Get the name of this function approximator
+   *  \return Name of this function approximator
+   */
+  virtual std::string getName(void) const = 0;
+  
+  void getSelectableParameters(std::set<std::string>& selected_values_labels) const;
+  void setSelectedParameters(const std::set<std::string>& selected_values_labels);
+  void getParameterVectorSelectedMinMax(Eigen::VectorXd& min, Eigen::VectorXd& max) const;
+  int getParameterVectorSelectedSize(void) const;
+  void setParameterVectorSelected(const Eigen::VectorXd& values, bool normalized=false);
+  void getParameterVectorSelected(Eigen::VectorXd& values, bool normalized=false) const;
+
+  void getParameterVectorMask(const std::set<std::string> selected_values_labels, Eigen::VectorXi& selected_mask) const;
+  int getParameterVectorAllSize(void) const;
+  void getParameterVectorAll(Eigen::VectorXd& values) const;
+  void setParameterVectorAll(const Eigen::VectorXd& values);
+
+
+  
+  /** Print to output stream. 
+   *
+   *  \param[in] output  Output stream to which to write to
+   *  \param[in] function_approximator Function approximator to write
+   *  \return    Output stream
+   *
+   *  \remark Calls virtual function FunctionApproximator::toString, which must be implemented by
+   * subclasses: http://stackoverflow.com/questions/4571611/virtual-operator
+   */ 
+  friend std::ostream& operator<<(std::ostream& output, const FunctionApproximator& function_approximator) {
+    output << function_approximator.toString();
+    return output;
+  }
+  
+  /** Returns a string representation of the object.
+   * \return A string representation of the object.
+   */
+  std::string toString(void) const;
+  
+  
+  /** Accessor for FunctionApproximator::meta_parameters_
+   *  \return The meta-parameters of the algorithm
+   */
+  const MetaParameters* getMetaParameters(void) const;
+  
+  /** Accessor for FunctionApproximator::model_parameters_
+   *  \return The model parameters of the trained model
+   */
+  const ModelParameters* getModelParameters(void) const;
+  
+  void setParameterVectorModifierPrivate(std::string modifier, bool new_value);
+  
+protected:
+
+  /** Accessor for FunctionApproximator::model_parameters_
+   *  \param[in] model_parameters The model parameters of a trained model
+   */
+  void setModelParameters(ModelParameters* model_parameters);
+  
+  
+  /**
+   * Default constructor.
+   * \remarks This default constuctor is required for boost::serialization to work. Since this
+   * constructor should not be called by other classes, it is private (boost::serialization is a
+   * friend)
+   */
+  FunctionApproximator(void) {};
+  
+private:
+  
+  /** The meta-parameters of the function approximator.
+   *
+   *  These are all the algorithmic parameters that are used when training the function 
+   *  approximator. These are thus only used in the FunctionApproximator::train function.
+   */
+  MetaParameters*  meta_parameters_;
+  
+  /** The model parameters of the function approximator.
+   *
+   *  These are all the parameters of a trained function approximator. These are determined when 
+   *  training the function approximator in FunctionApproximator::train, and used to make
+   *  predictions in FunctionApproximator::predict.
+   */
+  ModelParameters* model_parameters_;
+  
+  bool checkModelParametersInitialized(void) const;
+
+  /** Give boost serialization access to private members. */  
+  friend class boost::serialization::access;
+  
+  /** Serialize class data members to boost archive. 
+   * \param[in] ar Boost archive
+   * \param[in] version Version of the class
+   * See http://www.boost.org/doc/libs/1_55_0/libs/serialization/doc/tutorial.html#simplecase
+   */
+  template<class Archive>
+  void serialize(Archive & ar, const unsigned int version)
+  {
+    // serialize base class information
+    ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Parameterizable);
+    
+    ar & BOOST_SERIALIZATION_NVP(meta_parameters_);
+    ar & BOOST_SERIALIZATION_NVP(model_parameters_);
+  }
+
+};
+
+}
+
+
+/** Tell boost serialization that this class has pure virtual functions. */
+#include <boost/serialization/assume_abstract.hpp>
+BOOST_SERIALIZATION_ASSUME_ABSTRACT(DmpBbo::FunctionApproximator);
+ 
+/** Don't add version information to archives. */
+#include <boost/serialization/export.hpp>
+BOOST_CLASS_IMPLEMENTATION(DmpBbo::FunctionApproximator,boost::serialization::object_serializable);
+
+#endif // _FUNCTIONAPPROXIMATOR_H_
+
+/** \page page_func_approx Function Approximation Module
+
+\section sec_fa Function Approximation
+
+This module implements a set of function approximators, i.e. supervised learning algorithms that are trained with demonstration pairs input/target, after which they make predictions for new inputs. For simplicity, this module implements only batch learning (not incremental), and does not allow trained function approximators to be retrained.
+
+The two main functions are FunctionApproximator::train, which takes a set of inputs and corresponding targets, and FunctionApproximator::predict, which makes predictions for novel inputs. 
+
+\subsection sec_fa_metaparameters MetaParameters and ModelParameters
+
+In this module, algorithmic parameters are called MetaParameters, and the parameters of the model when the function approximator has been trained are called ModelParameters. The rationale for this is that an untrained function approximator can be entirely reconstructed if its MetaParameters are known; this is useful for saving to file and making copies. A trained function approximator can be compeletely reconstructed given only its ModelParameters.
+
+The life-cycle of a function approximator is as follows:
+
+\b 1. \b Initialization: The function approximator is initialized by calling the constructor with the MetaParameters. Its ModelParameters are set to NULL, indicating that the model is untrained.
+
+\b 2. \b Training: FunctionApproximator::train is called, which performs the conversion: \f$ \mbox{train}: \mbox{MetaParameters} \times \mbox{Inputs} \times \mbox{Targets} \mapsto \mbox{ModelParameters} \f$
+
+\b 3. \b Prediction: FunctionApproximator::predict is called, which performs the conversion: \f$ \mbox{predict}: \mbox{ModelParameters} \times \mbox{Input} \mapsto \mbox{Output}\f$
+
+\em Remark. FunctionApproximator::train in Step \b 2. may only be called once. If you explicitly want to retrain the function approximator with novel input/target data call FunctionApproximator::reTrain() instead.
+
+\em Remark. During the initialization, ModelParameters may also be passed to the constructor. This means that an already trained function approximator is initialized. Step \b 2. above is thus skipped.
+
+\subsection sec_fa_changing_modelparameters Changing the ModelParameters of a FunctionApproximator
+
+The user should not be allowed to set the ModelParameters of a trained function approximator directly. Hence, FunctionApproximator::setModelParameters is protected. However, in order to change the values inside the model parameters (for instance when optimizing them), the user may call ModelParameters::getParameterVectorSelected and ModelParameters::setParameterVectorSelected it inherits these functions from Parameterizable). These take a vector of doubles, check if the vector has the right size, and get/set the ModelParameters accordingly.
+
+Function approximators often have different types of model parameters. For instance, the model parameters of Locally Weighted Regression (FunctionApproximatorLWR) represent the centers and widths of the basis functions, as well as the slopes of the line segments. If you only want to get/set the slopes when calling ModelParameters::getParameterVectorSelected and ModelParameters::setParameterVectorSelected, you must use ModelParameters::setSelectedParameters(const std::set<std::string>& selected_values_labels), for instance as follows:
+
+\code
+std::set<std::string> selected;
+selected.insert("slopes");
+model_parameters.setSelectedParameters(selected);
+Eigen::VectorXd values;
+model_parameters.getParameterVectorSelected(values);
+// "values" now only contains the slopes of the line segments
+
+selected.clear();
+selected.insert("centers");
+selected.insert("slopes");
+model_parameters.setSelectedParameters(selected);
+model_parameters.getParameterVectorSelected(values);
+// "values" now contains the centers of the basis functions AND slopes of the line segments
+
+\endcode
+
+The rationale behind this implementation is that optimizers (such as evolution strategies) should not have to care about whether a particular set of model parameters contains centers, widths or slopes. Therefore, these different types of parameters are provided in one vector without semantics, and the generic interface is provided by the Parameterizable class.
+
+Classes that inherit from Parameterizable (such as all ModelParameters and FunctionApproximator subclasses, must implement the pure virtual methods Parameterizable::getParameterVectorAll Parameterizable::setParameterVectorAll and Parameterizable::getParameterVectorMask. Which gets/sets all the possible parameters in one vector, and a mask specifying the semantics of each value in the vector. The work of setting/getting the selected parameters (and normalizing them) is done in the Parameterizable class itself. This approach is a slightly longer run-time than doing the work in the subclasses, but it leads to more legible and robust code (less code duplication).
+ */

--- a/src/functionapproximators/FunctionApproximatorGMR.cpp
+++ b/src/functionapproximators/FunctionApproximatorGMR.cpp
@@ -20,7 +20,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
  */
-
+#define EIGEN2_SUPPORT
 #include <boost/serialization/export.hpp>
 #include <boost/archive/text_iarchive.hpp>
 #include <boost/archive/text_oarchive.hpp>

--- a/src/functionapproximators/FunctionApproximatorGMR.cpp~
+++ b/src/functionapproximators/FunctionApproximatorGMR.cpp~
@@ -1,0 +1,403 @@
+/**
+ * @file   FunctionApproximatorGMR.cpp
+ * @brief  FunctionApproximator class source file.
+ * @author Thibaut Munzer, Freek Stulp
+ *
+ * This file is part of DmpBbo, a set of libraries and programs for the 
+ * black-box optimization of dynamical movement primitives.
+ * Copyright (C) 2014 Freek Stulp, ENSTA-ParisTech
+ * 
+ * DmpBbo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ * 
+ * DmpBbo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <boost/serialization/export.hpp>
+#include <boost/archive/text_iarchive.hpp>
+#include <boost/archive/text_oarchive.hpp>
+#include <boost/archive/xml_iarchive.hpp>
+#include <boost/archive/xml_oarchive.hpp>
+#include "functionapproximators/FunctionApproximatorGMR.hpp"
+
+BOOST_CLASS_EXPORT_IMPLEMENT(DmpBbo::FunctionApproximatorGMR);
+
+#include <iostream> 
+#include <eigen3/Eigen/LU>
+#include <eigen3/Eigen/Cholesky>
+#include <ctime>
+#include <cstdlib>
+
+#include "functionapproximators/ModelParametersGMR.hpp"
+#include "functionapproximators/MetaParametersGMR.hpp"
+#include "dmpbbo_io/EigenBoostSerialization.hpp"
+
+
+using namespace std;
+using namespace Eigen;
+
+namespace DmpBbo {
+
+FunctionApproximatorGMR::FunctionApproximatorGMR(MetaParametersGMR* meta_parameters, ModelParametersGMR* model_parameters)
+:
+  FunctionApproximator(meta_parameters,model_parameters)
+{
+  // TODO : find a more appropriate place for rand initialization
+  srand(unsigned(time(0)));
+}
+
+FunctionApproximatorGMR::FunctionApproximatorGMR(ModelParametersGMR* model_parameters)
+:
+  FunctionApproximator(model_parameters)
+{
+}
+
+FunctionApproximator* FunctionApproximatorGMR::clone(void) const {
+  MetaParametersGMR* meta_params  = NULL;
+  if (getMetaParameters()!=NULL)
+    meta_params = dynamic_cast<MetaParametersGMR*>(getMetaParameters()->clone());
+
+  ModelParametersGMR* model_params = NULL;
+  if (getModelParameters()!=NULL)
+    model_params = dynamic_cast<ModelParametersGMR*>(getModelParameters()->clone());
+
+  if (meta_params==NULL)
+    return new FunctionApproximatorGMR(model_params);
+  else
+    return new FunctionApproximatorGMR(meta_params,model_params);
+};
+
+void FunctionApproximatorGMR::train(const MatrixXd& inputs, const MatrixXd& targets)
+{
+  if (isTrained())  
+  {
+    cerr << "WARNING: You may not call FunctionApproximatorGMR::train more than once. Doing nothing." << endl;
+    cerr << "   (if you really want to retrain, call reTrain function instead)" << endl;
+    return;
+  }
+  
+  assert(inputs.rows() == targets.rows()); // Must have same number of examples
+  assert(inputs.cols()==getExpectedInputDim());
+
+  const MetaParametersGMR* meta_parameters_GMR = 
+    static_cast<const MetaParametersGMR*>(getMetaParameters());
+
+  int nbGaussian = meta_parameters_GMR->number_of_gaussians_;
+  int gmmDim = inputs.cols() + targets.cols();
+
+  std::vector<VectorXd> gmmCenters;
+  std::vector<double> gmmPriors;
+  std::vector<MatrixXd> gmmCovars;
+
+  for (int i = 0; i < nbGaussian; i++)
+  {
+    gmmCenters.push_back(VectorXd(gmmDim));
+    gmmPriors.push_back(0.0);
+    gmmCovars.push_back(MatrixXd(gmmDim, gmmDim));
+  }
+
+  MatrixXd gmmData = MatrixXd(inputs.rows(), gmmDim);
+  gmmData << inputs, targets;
+
+  if (inputs.cols() == 1)
+    firstDimSlicingInit(gmmData, gmmCenters, gmmPriors, gmmCovars);
+  else
+    kMeansInit(gmmData, gmmCenters, gmmPriors, gmmCovars);
+  EM(gmmData, gmmCenters, gmmPriors, gmmCovars);
+
+  std::vector<VectorXd> centers;
+  std::vector<MatrixXd> slopes;
+  std::vector<VectorXd> biases;
+  std::vector<MatrixXd> inverseCovarsL;
+
+  int nbInDim = inputs.cols();
+  int nbOutDim = targets.cols();
+
+  for (int iCenter = 0; iCenter < nbGaussian; iCenter++)
+  {
+    centers.push_back(VectorXd(gmmCenters[iCenter].segment(0, nbInDim)));
+
+    slopes.push_back(MatrixXd(gmmCovars[iCenter].block(nbInDim, 0, nbOutDim, nbInDim) * gmmCovars[iCenter].block(0, 0, nbInDim, nbInDim).inverse()));
+    
+    biases.push_back(VectorXd(gmmCenters[iCenter].segment(nbInDim, nbOutDim) -
+      slopes[iCenter]*gmmCenters[iCenter].segment(0, nbInDim)));
+
+    MatrixXd L = gmmCovars[iCenter].block(0, 0, nbInDim, nbInDim).inverse().llt().matrixL();
+    inverseCovarsL.push_back(MatrixXd(L));
+  }
+
+  setModelParameters(new ModelParametersGMR(centers, gmmPriors, slopes, biases, inverseCovarsL));
+
+  //for (size_t i = 0; i < gmmCenters.size(); i++)
+  //  delete gmmCenters[i];
+  //for (size_t i = 0; i < gmmCovars.size(); i++)
+  //delete gmmCovars[i];
+}
+
+void FunctionApproximatorGMR::predict(const MatrixXd& input, MatrixXd& output)
+{
+  if (!isTrained())  
+  {
+    cerr << "WARNING: You may not call FunctionApproximatorGMR::predict if you have not trained yet. Doing nothing." << endl;
+    return;
+  }
+  
+  const ModelParametersGMR* model_parameters_GMR = static_cast<const ModelParametersGMR*>(getModelParameters());
+
+  int nbGaussian =  model_parameters_GMR->biases_.size();
+  int nbOutDim = model_parameters_GMR->biases_[0].size();
+
+  output = MatrixXd(input.rows(), nbOutDim);
+
+  for (int i = 0; i < input.rows(); i++)
+  {
+    VectorXd inputPoint = input.row(i);
+    VectorXd h(nbGaussian);
+    VectorXd partialH(nbGaussian);
+  
+    for (int iCenter = 0; iCenter < nbGaussian; iCenter++)
+    {
+      VectorXd center = model_parameters_GMR->centers_[iCenter];
+      partialH[iCenter] = -1. / 2 * ((inputPoint - center).transpose() * model_parameters_GMR->inverseCovarsL_[iCenter] *
+        model_parameters_GMR->inverseCovarsL_[iCenter].transpose() * (inputPoint - center))(0, 0);
+    }
+    double max = partialH.maxCoeff();
+    for (int iCenter = 0; iCenter < nbGaussian; iCenter++)
+      partialH[iCenter] -= max;
+
+    for (int iCenter = 0; iCenter < nbGaussian; iCenter++)
+    {
+      VectorXd center = model_parameters_GMR->centers_[iCenter];
+      double det = 1. / pow((model_parameters_GMR->inverseCovarsL_[iCenter]* model_parameters_GMR->inverseCovarsL_[iCenter].transpose()).determinant(), 2);
+      h[iCenter] = model_parameters_GMR->priors_[iCenter]*1. / sqrt(pow(2 * M_PI, center.rows()) * det) * exp(partialH[iCenter]);
+    }
+    h /= h.sum();
+
+    VectorXd prediction(nbOutDim);
+    prediction.setZero();
+    for (int iCenter = 0; iCenter < nbGaussian; iCenter++)
+    {
+      VectorXd tmp = model_parameters_GMR->slopes_[iCenter] * inputPoint;
+      prediction += h[iCenter] * (model_parameters_GMR->biases_[iCenter] + tmp);
+    }
+    output.row(i) = prediction;
+  }
+}
+
+void FunctionApproximatorGMR::firstDimSlicingInit(const MatrixXd& data, std::vector<VectorXd>& centers, std::vector<double>& priors,
+  std::vector<MatrixXd>& covars)
+{
+
+  VectorXd firstDim = data.col(0);
+
+  VectorXi assign(data.rows());
+  assign.setZero();
+
+  double minVal = firstDim.minCoeff();
+  double maxVal = firstDim.maxCoeff();
+
+  for (int iFirstDim = 0; iFirstDim < firstDim.size(); iFirstDim++)
+  {
+    size_t center = int((firstDim[iFirstDim] - minVal) / (maxVal - minVal) * centers.size());
+
+    if (center == centers.size())
+      center--;
+
+    assign[iFirstDim] = center;
+  }
+  
+  // Init means
+  VectorXi nbPoints = VectorXi::Zero(centers.size());
+  for (size_t iCenter = 0; iCenter < centers.size(); iCenter++)
+    centers[iCenter].setZero();
+  for (int iData = 0; iData < data.rows(); iData++)
+  {
+    centers[assign[iData]] += data.row(iData).transpose();
+    nbPoints[assign[iData]]++;
+  }
+  for (size_t iCenter = 0; iCenter < centers.size(); iCenter++)
+    centers[iCenter] /= nbPoints[iCenter];
+
+  // Init covars
+  for (size_t iCenter = 0; iCenter < centers.size(); iCenter++)
+    covars[iCenter].setZero();
+  for (int iData = 0; iData < data.rows(); iData++)
+    covars[assign[iData]] += (data.row(iData).transpose() - centers[assign[iData]]) * (data.row(iData).transpose() - centers[assign[iData]]).transpose();
+  for (size_t iCenter = 0; iCenter < centers.size(); iCenter++)
+    covars[iCenter] /= nbPoints[iCenter];
+
+  // Be sure that covar is invertible
+  for (size_t iCenter = 0; iCenter < centers.size(); iCenter++)
+      covars[iCenter] += MatrixXd::Identity(covars[iCenter].rows(), covars[iCenter].cols()) * 1e-5;
+
+  // Init priors
+  for (size_t iCenter = 0; iCenter < centers.size(); iCenter++)
+    priors[iCenter] = 1. / centers.size();
+}
+
+void FunctionApproximatorGMR::kMeansInit(const MatrixXd& data, std::vector<VectorXd>& centers, std::vector<double>& priors,
+  std::vector<MatrixXd>& covars, int nbMaxIter)
+{
+
+  MatrixXd dataCentered = data.rowwise() - data.colwise().mean();
+  MatrixXd dataCov = dataCentered.transpose() * dataCentered / data.rows();
+  MatrixXd dataCovInverse = dataCov.inverse();
+
+  std::vector<int> dataIndex;
+  for (int i = 0; i < data.rows(); i++)
+    dataIndex.push_back(i); 
+  std::random_shuffle (dataIndex.begin(), dataIndex.end());
+
+  for (size_t iCenter = 0; iCenter < centers.size(); iCenter++)
+    centers[iCenter] = data.row(dataIndex[iCenter]);
+
+  VectorXi assign(data.rows());
+  assign.setZero();
+
+  bool converged = false;
+  for (int iIter = 0; iIter < nbMaxIter && !converged; iIter++)
+  {
+    // E step
+    converged = true;
+    for (int iData = 0; iData < data.rows(); iData++)
+    {
+      VectorXd v = (centers[assign[iData]] - data.row(iData).transpose());
+
+      double minDist = v.transpose() * dataCovInverse * v;
+
+      for (int iCenter = 0; iCenter < (int)centers.size(); iCenter++)
+      {
+        if (iCenter == assign[iData])
+          continue;
+
+        v = (centers[iCenter] - data.row(iData).transpose());
+        double dist = v.transpose() * dataCovInverse * v;
+        if (dist < minDist)
+        {
+          converged = false;
+          minDist = dist;
+          assign[iData] = iCenter;
+        }
+      }
+    }
+
+    // M step
+    VectorXi nbPoints = VectorXi::Zero(centers.size());
+    for (size_t iCenter = 0; iCenter < centers.size(); iCenter++)
+      centers[iCenter].setZero();
+    for (int iData = 0; iData < data.rows(); iData++)
+    {
+      centers[assign[iData]] += data.row(iData).transpose();
+      nbPoints[assign[iData]]++;
+    }
+    for (size_t iCenter = 0; iCenter < centers.size(); iCenter++)
+      centers[iCenter] /= nbPoints[iCenter];
+  }
+
+  // Init covars
+  VectorXi nbPoints = VectorXi::Zero(centers.size());
+  for (size_t iCenter = 0; iCenter < centers.size(); iCenter++)
+    covars[iCenter].setZero();
+  for (int iData = 0; iData < data.rows(); iData++)
+  {
+    covars[assign[iData]] += (data.row(iData).transpose() - centers[assign[iData]]) * (data.row(iData).transpose() - centers[assign[iData]]).transpose();
+    nbPoints[assign[iData]]++;
+  }
+  for (size_t iCenter = 0; iCenter < centers.size(); iCenter++)
+    covars[iCenter] /= nbPoints[iCenter];
+
+  // Be sure that covar is invertible
+  for (size_t iCenter = 0; iCenter < centers.size(); iCenter++)
+    covars[iCenter] += MatrixXd::Identity(covars[iCenter].rows(), covars[iCenter].cols()) * 1e-5f;
+
+  // Init priors
+  for (size_t iCenter = 0; iCenter < centers.size(); iCenter++)
+    priors[iCenter] = 1. / centers.size();
+}
+
+void FunctionApproximatorGMR::EM(const MatrixXd& data, std::vector<VectorXd>& centers, std::vector<double>& priors,
+    std::vector<MatrixXd>& covars, int nbMaxIter)
+{
+  MatrixXd assign(centers.size(), data.rows());
+  assign.setZero();
+
+  double oldLoglik = -1e10f;
+  double loglik = 0;
+
+  for (int iIter = 0; iIter < nbMaxIter; iIter++)
+  {
+    // E step
+    for (int iData = 0; iData < data.rows(); iData++)
+      for (size_t iCenter = 0; iCenter < centers.size(); iCenter++)
+        assign(iCenter, iData) = priors[iCenter] * normal(data.row(iData).transpose(), centers[iCenter], covars[iCenter]);
+
+    oldLoglik = loglik;
+    loglik = 0;
+    for (int iData = 0; iData < data.rows(); iData++)
+      loglik += log(assign.col(iData).sum());
+    loglik /= data.rows();
+
+    if (fabs(loglik / oldLoglik - 1) < 1e-8f)
+      break;
+
+    for (int iData = 0; iData < data.rows(); iData++)
+      assign.col(iData) /= assign.col(iData).sum();
+
+    // M step
+    for (size_t iCenter = 0; iCenter < centers.size(); iCenter++)
+    {
+      centers[iCenter].setZero();
+      covars[iCenter].setZero();
+      priors[iCenter] = 0;
+    }
+
+    for (int iData = 0; iData < data.rows(); iData++)
+    {
+      for (size_t iCenter = 0; iCenter < centers.size(); iCenter++)
+      {
+        centers[iCenter] += assign(iCenter, iData) * data.row(iData).transpose();
+        priors[iCenter] += assign(iCenter, iData);
+      }
+    }
+
+    for (size_t iCenter = 0; iCenter < centers.size(); iCenter++)
+    {
+      centers[iCenter] /= assign.row(iCenter).sum();
+      priors[iCenter] /= assign.cols();
+    }
+
+    for (int iData = 0; iData < data.rows(); iData++)
+      for (size_t iCenter = 0; iCenter < centers.size(); iCenter++)
+        covars[iCenter] += assign(iCenter, iData) * (data.row(iData).transpose() - centers[iCenter]) * (data.row(iData).transpose() - centers[iCenter]).transpose();
+
+    for (size_t iCenter = 0; iCenter < centers.size(); iCenter++)
+      covars[iCenter] /= assign.row(iCenter).sum();
+
+    // Be sure that covar is invertible
+    for (size_t iCenter = 0; iCenter < centers.size(); iCenter++)
+      covars[iCenter] += MatrixXd::Identity(covars[iCenter].rows(), covars[iCenter].cols()) * 1e-5f;
+  }
+}
+
+double FunctionApproximatorGMR::normal(const VectorXd& data, const VectorXd& center, const MatrixXd& cov)
+{
+  double tmp = -1. / 2 * ((data - center).transpose() * cov.inverse() * (data - center))(0, 0);
+  return 1. / sqrt(pow(2 * M_PI, center.cols()) * cov.determinant()) * exp(tmp);
+}
+
+template<class Archive>
+void FunctionApproximatorGMR::serialize(Archive & ar, const unsigned int version)
+{
+  // serialize base class information
+  ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(FunctionApproximator);
+}
+
+}

--- a/src/functionapproximators/FunctionApproximatorIRFRLS.cpp
+++ b/src/functionapproximators/FunctionApproximatorIRFRLS.cpp
@@ -20,7 +20,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
  */
- 
+#define EIGEN2_SUPPORT 
 #include <boost/serialization/export.hpp>
 #include <boost/archive/text_iarchive.hpp>
 #include <boost/archive/text_oarchive.hpp>

--- a/src/functionapproximators/FunctionApproximatorIRFRLS.cpp~
+++ b/src/functionapproximators/FunctionApproximatorIRFRLS.cpp~
@@ -1,0 +1,166 @@
+/**
+ * @file   FunctionApproximatorIRFRLS.cpp
+ * @brief  FunctionApproximator class source file.
+ * @author Thibaut Munzer, Freek Stulp
+ *
+ * This file is part of DmpBbo, a set of libraries and programs for the 
+ * black-box optimization of dynamical movement primitives.
+ * Copyright (C) 2014 Freek Stulp, ENSTA-ParisTech
+ * 
+ * DmpBbo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ * 
+ * DmpBbo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
+#include <boost/serialization/export.hpp>
+#include <boost/archive/text_iarchive.hpp>
+#include <boost/archive/text_oarchive.hpp>
+#include <boost/archive/xml_iarchive.hpp>
+#include <boost/archive/xml_oarchive.hpp>
+#include "functionapproximators/FunctionApproximatorIRFRLS.hpp"
+
+BOOST_CLASS_EXPORT_IMPLEMENT(DmpBbo::FunctionApproximatorIRFRLS);
+
+#include "functionapproximators/MetaParametersIRFRLS.hpp"
+#include "functionapproximators/ModelParametersIRFRLS.hpp"
+
+#include "dmpbbo_io/EigenBoostSerialization.hpp"
+
+#include <eigen3/Eigen/LU>
+
+#include <boost/math/constants/constants.hpp>
+#include <boost/random.hpp>
+#include <boost/random/variate_generator.hpp>
+#include <boost/random/normal_distribution.hpp>
+#include <boost/random/uniform_real.hpp>
+
+#include <iostream>
+
+using namespace Eigen;
+using namespace std;
+
+namespace DmpBbo {
+
+FunctionApproximatorIRFRLS::FunctionApproximatorIRFRLS(MetaParametersIRFRLS* meta_parameters, ModelParametersIRFRLS* model_parameters)
+:
+  FunctionApproximator(meta_parameters,model_parameters)
+{
+}
+
+FunctionApproximatorIRFRLS::FunctionApproximatorIRFRLS(ModelParametersIRFRLS* model_parameters)
+:
+  FunctionApproximator(model_parameters)
+{
+}
+
+FunctionApproximator* FunctionApproximatorIRFRLS::clone(void) const {
+  MetaParametersIRFRLS*  meta_params  = NULL;
+  if (getMetaParameters()!=NULL)
+    meta_params = dynamic_cast<MetaParametersIRFRLS*>(getMetaParameters()->clone());
+
+  ModelParametersIRFRLS* model_params = NULL;
+  if (getModelParameters()!=NULL)
+    model_params = dynamic_cast<ModelParametersIRFRLS*>(getModelParameters()->clone());
+
+  if (meta_params==NULL)
+    return new FunctionApproximatorIRFRLS(model_params);
+  else
+    return new FunctionApproximatorIRFRLS(meta_params,model_params);
+};
+
+
+void FunctionApproximatorIRFRLS::train(const MatrixXd& inputs, const MatrixXd& targets)
+{
+  if (isTrained())  
+  {
+    cerr << "WARNING: You may not call FunctionApproximatorIRFRLS::train more than once. Doing nothing." << endl;
+    cerr << "   (if you really want to retrain, call reTrain function instead)" << endl;
+    return;
+  }
+  
+  assert(inputs.rows() == targets.rows()); // Must have same number of examples
+  assert(inputs.cols()==getExpectedInputDim());
+  
+  const MetaParametersIRFRLS* meta_parameters_irfrls = 
+    static_cast<const MetaParametersIRFRLS*>(getMetaParameters());
+
+  int nb_cos = meta_parameters_irfrls->number_of_basis_functions_;
+
+  // Init random generator.
+  boost::mt19937 rng(getpid() + time(0));
+
+  // Draw periodes
+  boost::normal_distribution<> twoGamma(0, sqrt(2 * meta_parameters_irfrls->gamma_));
+  boost::variate_generator<boost::mt19937&, boost::normal_distribution<> > genPeriods(rng, twoGamma);
+  MatrixXd cosines_periodes(nb_cos, inputs.cols());
+  for (int r = 0; r < nb_cos; r++)
+    for (int c = 0; c < inputs.cols(); c++)
+      cosines_periodes(r, c) = genPeriods();
+
+  // Draw phase
+  boost::uniform_real<> twoPi(0, 2 * boost::math::constants::pi<double>());
+  boost::variate_generator<boost::mt19937&, boost::uniform_real<> > genPhases(rng, twoPi);
+  VectorXd cosines_phase(nb_cos);
+  for (int r = 0; r < nb_cos; r++)
+      cosines_phase(r) = genPhases();
+
+  MatrixXd proj_inputs;
+  proj(inputs, cosines_periodes, cosines_phase, proj_inputs);
+
+  // Compute linear model analatically
+  double lambda = meta_parameters_irfrls->lambda_;
+  MatrixXd toInverse = lambda * MatrixXd::Identity(nb_cos, nb_cos) + proj_inputs.transpose() * proj_inputs;
+  VectorXd linear_model = toInverse.inverse() *
+    (proj_inputs.transpose() * targets);
+
+  setModelParameters(new ModelParametersIRFRLS(linear_model, cosines_periodes, cosines_phase));
+}
+
+void FunctionApproximatorIRFRLS::predict(const MatrixXd& input, MatrixXd& output)
+{
+  if (!isTrained())  
+  {
+    cerr << "WARNING: You may not call FunctionApproximatorIRFRLS::predict if you have not trained yet. Doing nothing." << endl;
+    return;
+  }
+  
+  const ModelParametersIRFRLS* model_parameters_irfrls = static_cast<const ModelParametersIRFRLS*>(getModelParameters());
+
+  MatrixXd proj_inputs;
+  proj(input, model_parameters_irfrls->cosines_periodes_, model_parameters_irfrls->cosines_phase_, proj_inputs);
+  output = proj_inputs * model_parameters_irfrls->linear_models_;
+}
+
+/** Cosinus function. Used to select correct overload version of cos in FunctionApproximatorIRFRLS::proj
+ * \param[in]  x A decimal number
+ * \return The cosinus of x
+ */
+double double_cosine(double x)
+{
+  return cos(x);
+}
+
+void FunctionApproximatorIRFRLS::proj(const MatrixXd& vecs, const MatrixXd& periods, const VectorXd& phases, Eigen::MatrixXd& projected)
+{
+  projected = vecs * periods.transpose();
+  projected.rowwise() += phases.transpose();
+  projected = projected.unaryExpr(ptr_fun(double_cosine));
+}
+
+template<class Archive>
+void FunctionApproximatorIRFRLS::serialize(Archive & ar, const unsigned int version)
+{
+  // serialize base class information
+  ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(FunctionApproximator);
+}
+
+}

--- a/src/functionapproximators/FunctionApproximatorLWR.cpp
+++ b/src/functionapproximators/FunctionApproximatorLWR.cpp
@@ -20,7 +20,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
  */
-
+//#define EIGEN2_SUPPORT
 #include <boost/serialization/export.hpp>
 #include <boost/archive/text_iarchive.hpp>
 #include <boost/archive/text_oarchive.hpp>

--- a/src/functionapproximators/FunctionApproximatorLWR.cpp~
+++ b/src/functionapproximators/FunctionApproximatorLWR.cpp~
@@ -1,0 +1,268 @@
+/**
+ * @file   FunctionApproximatorLWR.cpp
+ * @brief  FunctionApproximatorLWR class source file.
+ * @author Freek Stulp
+ *
+ * This file is part of DmpBbo, a set of libraries and programs for the 
+ * black-box optimization of dynamical movement primitives.
+ * Copyright (C) 2014 Freek Stulp, ENSTA-ParisTech
+ * 
+ * DmpBbo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ * 
+ * DmpBbo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#define EIGEN2_SUPPORT
+#include <boost/serialization/export.hpp>
+#include <boost/archive/text_iarchive.hpp>
+#include <boost/archive/text_oarchive.hpp>
+#include <boost/archive/xml_iarchive.hpp>
+#include <boost/archive/xml_oarchive.hpp>
+#include "functionapproximators/FunctionApproximatorLWR.hpp"
+
+BOOST_CLASS_EXPORT_IMPLEMENT(DmpBbo::FunctionApproximatorLWR);
+
+#include "functionapproximators/ModelParametersLWR.hpp"
+#include "functionapproximators/MetaParametersLWR.hpp"
+
+#include "dmpbbo_io/EigenBoostSerialization.hpp"
+
+#include <iostream>
+#include <eigen3/Eigen/SVD>
+#include <eigen3/Eigen/LU>
+
+using namespace std;
+using namespace Eigen;
+
+namespace DmpBbo {
+
+FunctionApproximatorLWR::FunctionApproximatorLWR(MetaParametersLWR *meta_parameters, ModelParametersLWR *model_parameters) 
+:
+  FunctionApproximator(meta_parameters,model_parameters)
+{
+}
+
+FunctionApproximatorLWR::FunctionApproximatorLWR(ModelParametersLWR *model_parameters) 
+:
+  FunctionApproximator(model_parameters)
+{
+}
+
+
+FunctionApproximator* FunctionApproximatorLWR::clone(void) const {
+
+  MetaParametersLWR*  meta_params  = NULL;
+  if (getMetaParameters()!=NULL)
+    meta_params = dynamic_cast<MetaParametersLWR*>(getMetaParameters()->clone());
+
+  ModelParametersLWR* model_params = NULL;
+  if (getModelParameters()!=NULL)
+    model_params = dynamic_cast<ModelParametersLWR*>(getModelParameters()->clone());
+
+  if (meta_params==NULL)
+    return new FunctionApproximatorLWR(model_params);
+  else
+    return new FunctionApproximatorLWR(meta_params,model_params);
+};
+
+
+
+/** Compute Moore-Penrose pseudo-inverse. 
+ * Taken from: http://eigen.tuxfamily.org/bz/show_bug.cgi?id=257
+ * \param[in]  a       The matrix to be inversed.
+ * \param[out] result  The pseudo-inverse of the matrix.
+ * \param[in]  epsilon Don't know, not my code ;-)
+ * \return     true if pseudo-inverse possible, false otherwise
+ */
+template<typename _Matrix_Type_>
+bool pseudoInverse(const _Matrix_Type_ &a, _Matrix_Type_ &result, double
+epsilon = std::numeric_limits<typename _Matrix_Type_::Scalar>::epsilon())
+{
+  if(a.rows()<a.cols())
+      return false;
+
+  Eigen::JacobiSVD< _Matrix_Type_ > svd = a.jacobiSvd(Eigen::ComputeThinU |
+Eigen::ComputeThinV);
+
+  typename _Matrix_Type_::Scalar tolerance = epsilon * std::max(a.cols(),
+a.rows()) * svd.singularValues().array().abs().maxCoeff();
+
+  result = svd.matrixV() * _Matrix_Type_( (svd.singularValues().array().abs() >
+tolerance).select(svd.singularValues().
+      array().inverse(), 0) ).asDiagonal() * svd.matrixU().adjoint();
+      
+  return true;
+}
+
+
+void FunctionApproximatorLWR::train(const MatrixXd& inputs, const MatrixXd& targets)
+{
+  if (isTrained())  
+  {
+    cerr << "WARNING: You may not call FunctionApproximatorLWR::train more than once. Doing nothing." << endl;
+    cerr << "   (if you really want to retrain, call reTrain function instead)" << endl;
+    return;
+  }
+  
+  assert(inputs.rows() == targets.rows());
+  assert(inputs.cols()==getExpectedInputDim());
+
+  const MetaParametersLWR* meta_parameters_lwr = 
+    dynamic_cast<const MetaParametersLWR*>(getMetaParameters());
+  
+  VectorXd min = inputs.colwise().minCoeff();
+  VectorXd max = inputs.colwise().maxCoeff();
+  
+  MatrixXd centers, widths, activations;
+  meta_parameters_lwr->getCentersAndWidths(min,max,centers,widths);
+  bool asym_kernels = meta_parameters_lwr->asymmetric_kernels(); 
+  ModelParametersLWR::normalizedKernelActivations(centers,widths,inputs,activations,asym_kernels);
+  
+  // Make the design matrix
+  MatrixXd X = MatrixXd::Ones(inputs.rows(),inputs.cols()+1);
+  X.leftCols(inputs.cols()) = inputs;
+  
+  
+  int n_kernels = activations.cols();
+  int n_betas = X.cols(); 
+  int n_samples = X.rows(); 
+  MatrixXd W;
+  MatrixXd beta(n_kernels,n_betas);
+  
+  double epsilon = 0.000001*activations.maxCoeff();
+  for (int bb=0; bb<n_kernels; bb++)
+  {
+    VectorXd W_vec = activations.col(bb);
+    
+    if (epsilon==0)
+    {
+      // Use all data
+      
+      W = W_vec.asDiagonal();
+      // Compute beta
+      // 1 x n_betas 
+      // = inv( (n_betas x n_sam)*(n_sam x n_sam)*(n_sam*n_betas) )*( (n_betas x n_sam)*(n_sam x n_sam)*(n_sam * 1) )   
+      // = inv(n_betas x n_betas)*(n_betas x 1)
+      VectorXd cur_beta = (X.transpose()*W*X).inverse()*X.transpose()*W*targets;
+      beta.row(bb)   =    cur_beta;
+    } 
+    else
+    {
+      // Very low weights do not contribute to the line fitting
+      // Therefore, we can delete the rows in W, X and targets for which W is small
+      //
+      // Example with epsilon = 0.1 (a very high value!! usually it will be lower)
+      //    W =       [0.001 0.01 0.5 0.98 0.46 0.01 0.001]^T
+      //    X =       [0.0   0.1  0.2 0.3  0.4  0.5  0.6 ; 
+      //               1.0   1.0  1.0 1.0  1.0  1.0  1.0  ]^T  (design matrix, so last column = 1)
+      //    targets = [1.0   0.5  0.4 0.5  0.6  0.7  0.8  ]
+      //
+      // will reduce to
+      //    W_sub =       [0.5 0.98 0.46 ]^T
+      //    X_sub =       [0.2 0.3  0.4 ; 
+      //                   1.0 1.0  1.0  ]^T  (design matrix, last column = 1)
+      //    targets_sub = [0.4 0.5  0.6  ]
+      // 
+      // Why all this trouble? Because the submatrices will often be much smaller than the full
+      // ones, so they are much faster to invert (note the .inverse() call)
+      
+      // Get a vector where 1 represents that W_vec >= epsilon, and 0 otherswise
+      VectorXi large_enough = (W_vec.array() >= epsilon).select(VectorXi::Ones(W_vec.size()), VectorXi::Zero(W_vec.size()));
+
+      // Number of samples in the submatrices
+      int n_samples_sub = large_enough.sum();
+    
+      // This would be a 1-liner in Matlab... but Eigen is not good with splicing.
+      VectorXd W_vec_sub(n_samples_sub);
+      MatrixXd X_sub(n_samples_sub,n_betas);
+      MatrixXd targets_sub(n_samples_sub,targets.cols());
+      int jj=0;
+      for (int ii=0; ii<n_samples; ii++)
+      {
+        if (large_enough[ii]==1)
+        {
+          W_vec_sub[jj] = W_vec[ii];
+          X_sub.row(jj) = X.row(ii);
+          targets_sub.row(jj) = targets.row(ii);
+          jj++;
+        }
+      }
+      
+      // Do the same inversion as above, but with only a small subset of the data
+      MatrixXd W_sub = W_vec_sub.asDiagonal();
+      VectorXd cur_beta_sub = (X_sub.transpose()*W_sub*X_sub).inverse()*X_sub.transpose()*W_sub*targets_sub;
+   
+      //cout << "  n_samples=" << n_samples << endl;
+      //cout << "  n_samples_sub=" << n_samples_sub << endl;
+      //cout << cur_beta.transpose() << endl;
+      //cout << cur_beta_sub.transpose() << endl;
+      beta.row(bb)   =    cur_beta_sub;
+    }
+  }
+  MatrixXd offsets = beta.rightCols(1);
+  MatrixXd slopes = beta.leftCols(n_betas-1);
+  
+  setModelParameters(new ModelParametersLWR(centers,widths,slopes,offsets,asym_kernels));
+  
+}
+
+void FunctionApproximatorLWR::predict(const MatrixXd& inputs, MatrixXd& output)
+{
+  if (!isTrained())  
+  {
+    cerr << "WARNING: You may not call FunctionApproximatorLWPR::predict if you have not trained yet. Doing nothing." << endl;
+    return;
+  }
+
+  // The following line of code took a long time to decide on.
+  // The member FunctionApproximator::model_parameters_ (which we access through
+  // getModelParameters()) is of class ModelParameters, not ModelParametersLWR.
+  // So within this function, we need to cast it to ModelParametersLWR in order to make predictions.
+  // There are three options to do this:
+  //
+  // 1) use a dynamic_cast. This is really the best way to do it, but the execution of dynamic_cast
+  //    can take relatively long, so we should avoid calling it in this time-critical function
+  //    predict() function. (note: because it doesn't matter so much for the non time-critical
+  //    train() function above, we  use the preferred dynamic_cast<MetaParametersLWR*> as we should)
+  //
+  // 2) move the model_parameters_ member from FunctionApproximator to FunctionApproximatorLWR, and 
+  //    make it ModelParametersLWR instead of ModelParameters. This, however, will lead to lots of 
+  //    code duplication, because each derived function approximator class will have to do this.
+  //
+  // 3) Do a static_cast. The static cast does not do checking like dynamic_cast, so we have to be
+  //    really sure that getModelParameters returns a ModelParametersLWR. The only way in which this 
+  //    could wrong is if someone calls setModelParameters() with a different derived class. And
+  //    this is near-impossible, because setModelParameters is protected within 
+  //    FunctionApproximator, and a derived class would be really dumb to set ModelParametersAAA 
+  //    with setModelParameters and expect getModelParameters to return ModelParametersBBB. 
+  //
+  // So I decided to go with 3) because it is fast and does not lead to code duplication, 
+  // and only real dumb derived classes can cause trouble ;-)
+  //
+  // Note: The execution time difference between 2) and 3) is negligible:  
+  //   No cast    : 8.90 microseconds/prediction of 1 input sample
+  //   Static cast: 8.91 microseconds/prediction of 1 input sample
+  //
+  // There, ~30 lines of comment for one line of code ;-) 
+  //                                            (mostly for me to remember why it is like this) 
+  const ModelParametersLWR* model_parameters_lwr = static_cast<const ModelParametersLWR*>(getModelParameters());
+  
+  model_parameters_lwr->locallyWeightedLines(inputs, output);
+}
+
+template<class Archive>
+void FunctionApproximatorLWR::serialize(Archive & ar, const unsigned int version)
+{
+  // serialize base class information
+  ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(FunctionApproximator);
+}
+
+}

--- a/src/functionapproximators/MetaParametersLWPR.hpp
+++ b/src/functionapproximators/MetaParametersLWPR.hpp
@@ -23,7 +23,7 @@
 
 #ifndef METAPARAMETERSLWPR_H
 #define METAPARAMETERSLWPR_H
-
+#define EIGEN2_SUPPORT
 #include "functionapproximators/MetaParameters.hpp"
 
 #include <eigen3/Eigen/Core>

--- a/src/functionapproximators/MetaParametersLWPR.hpp~
+++ b/src/functionapproximators/MetaParametersLWPR.hpp~
@@ -1,0 +1,138 @@
+/**
+ * @file   MetaParametersLWPR.hpp
+ * @brief  MetaParametersLWPR class header file.
+ * @author Freek Stulp
+ *
+ * This file is part of DmpBbo, a set of libraries and programs for the 
+ * black-box optimization of dynamical movement primitives.
+ * Copyright (C) 2014 Freek Stulp, ENSTA-ParisTech
+ * 
+ * DmpBbo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ * 
+ * DmpBbo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef METAPARAMETERSLWPR_H
+#define METAPARAMETERSLWPR_H
+
+#include "functionapproximators/MetaParameters.hpp"
+
+#include <eigen3/Eigen/Core>
+
+namespace DmpBbo {
+
+/** \brief Meta-parameters for the Locally Weighted Projection Regression (LWPR) function approximator
+ * \ingroup FunctionApproximators
+ * \ingroup LWPR
+ */
+class MetaParametersLWPR : public MetaParameters
+{
+  friend class FunctionApproximatorLWPR;
+
+public:
+  
+  /** Constructor for the algorithmic meta-parameters of the LWPR function approximator.
+   *
+   *  The meaning of these parameters is explained here:
+   *     http://wcms.inf.ed.ac.uk/ipab/slmc/research/software-lwpr
+   *
+   *  Short howto:
+   *  \li Set update_D=false, diag_only=true, use_meta=false
+   *  \li Tune init_D, and then w_gen and w_prune
+   *  \li Set update_D=true, then tune init_alpha, then penalty
+   *  \li Set diag_only=false, see if it helps, if so re-tune init_alpha if necessary
+   *  \li Set use_meta=true, tune meta_rate (I never do this...)  
+   *
+   *  \param[in] expected_input_dim Expected dimensionality of the input data
+   *
+   *  \param[in] init_D  Removing/adding kernels: Width of a kernel when it is newly placed. Smaller *                     values mean wider kernels.
+   *  \param[in] w_gen   Removing/adding kernels: Threshold for adding a kernel.
+   *  \param[in] w_prune Removing/adding kernels: Threshold for pruning a kernel.
+   *
+   *  \param[in] update_D   Updating existing kernels: whether to update kernels
+   *  \param[in] init_alpha Updating existing kernels: rate at which kernels are updated
+   *  \param[in] penalty    Updating existing kernels: regularization term. Higher penalty means
+   *                        less kernels.
+   *  \param[in] diag_only  Whether to update only the diagonal of the covariance matrix of the
+   *                        kernel, or the full matrix. 
+   * 
+   *  \param[in] use_meta    Meta-learning of kernel update rate: whether meta-learning is enabled
+   *  \param[in] meta_rate   Meta-learning of kernel update rate: meta-learning rate
+   * 
+   *  \param[in] kernel_name Removing/adding kernels: Type of kernels
+   */
+	MetaParametersLWPR(
+	  int expected_input_dim,
+    Eigen::VectorXd init_D=Eigen::VectorXd::Ones(1),
+    double   w_gen=0.2,
+    double   w_prune=0.8,
+             
+    bool     update_D=true,
+    double   init_alpha=1.0,
+    double   penalty=1.0,
+    bool     diag_only=true,
+             
+    bool     use_meta=false,
+    double   meta_rate=1.0,
+    std::string   kernel_name=std::string("Gaussian")
+  );
+		
+	MetaParametersLWPR* clone(void) const;
+
+  std::string toString(void) const;
+
+private:
+  Eigen::VectorXd init_D_; // If of size 1, call setInitD(double), else setInitD(vector<double>)
+  double w_gen_;
+  double w_prune_;
+    
+  bool   update_D_;
+  double init_alpha_;
+  double penalty_;
+  bool   diag_only_;
+  
+  bool   use_meta_;
+  double meta_rate_;
+  std::string kernel_name_; // "Gaussian" "BiSquare"
+
+  /**
+   * Default constructor.
+   * \remarks This default constuctor is required for boost::serialization to work. Since this
+   * constructor should not be called by other classes, it is private (boost::serialization is a
+   * friend)
+   */
+   MetaParametersLWPR(void) {};
+   
+  /** Give boost serialization access to private members. */  
+  friend class boost::serialization::access;
+  
+  /** Serialize class data members to boost archive. 
+   * \param[in] ar Boost archive
+   * \param[in] version Version of the class
+   * See http://www.boost.org/doc/libs/1_55_0/libs/serialization/doc/tutorial.html#simplecase
+   */
+  template<class Archive>
+  void serialize(Archive & ar, const unsigned int version);
+
+};
+
+}
+
+#include <boost/serialization/export.hpp>
+/** Register this derived class. */
+BOOST_CLASS_EXPORT_KEY2(DmpBbo::MetaParametersLWPR, "MetaParametersLWPR")
+
+/** Don't add version information to archives. */
+BOOST_CLASS_IMPLEMENTATION(DmpBbo::MetaParametersLWPR,boost::serialization::object_serializable);
+
+#endif        //  #ifndef METAPARAMETERSLWPR_H
+

--- a/src/functionapproximators/MetaParametersLWR.hpp
+++ b/src/functionapproximators/MetaParametersLWR.hpp
@@ -23,7 +23,7 @@
  
 #ifndef METAPARAMETERSLWR_H
 #define METAPARAMETERSLWR_H
-
+#define EIGEN2_SUPPORT
 #include "functionapproximators/MetaParameters.hpp"
 
 #include <iosfwd>

--- a/src/functionapproximators/MetaParametersLWR.hpp~
+++ b/src/functionapproximators/MetaParametersLWR.hpp~
@@ -1,0 +1,137 @@
+/**
+ * @file   MetaParametersLWR.hpp
+ * @brief  MetaParametersLWR class header file.
+ * @author Freek Stulp
+ *
+ * This file is part of DmpBbo, a set of libraries and programs for the 
+ * black-box optimization of dynamical movement primitives.
+ * Copyright (C) 2014 Freek Stulp, ENSTA-ParisTech
+ * 
+ * DmpBbo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ * 
+ * DmpBbo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
+#ifndef METAPARAMETERSLWR_H
+#define METAPARAMETERSLWR_H
+//#define EIGEN2_SUPPORT
+#include "functionapproximators/MetaParameters.hpp"
+
+#include <iosfwd>
+#include <vector>
+#include <eigen3/Eigen/Core>
+
+namespace DmpBbo {
+
+/** \brief Meta-parameters for the Locally Weighted Regression (LWR) function approximator
+ * \ingroup FunctionApproximators
+ * \ingroup LWR
+ */
+class MetaParametersLWR : public MetaParameters
+{
+  
+public:
+  
+  /** Constructor for the algorithmic meta-parameters of the LWR function approximator.
+   *  \param[in] expected_input_dim         The dimensionality of the data this function approximator expects. Although this information is already contained in the 'centers_per_dim' argument, we ask the user to pass it explicitly so that various checks on the arguments may be conducted.
+   *  \param[in] centers_per_dim Centers of the basis functions, one VectorXd for each dimension.
+   *  \param[in] intersection_height The value at which two neighbouring basis functions will intersect.
+   * \param[in] asymmetric_kernels Whether to use asymmetric kernels or not (to be documented, default is false)
+   */
+   MetaParametersLWR(int expected_input_dim, const std::vector<Eigen::VectorXd>& centers_per_dim, double intersection_height=0.5, bool asymmetric_kernels=false);
+		 
+  /** Constructor for the algorithmic meta-parameters of the LWR function approximator.
+   *  \param[in] expected_input_dim         The dimensionality of the data this function approximator expects. Although this information is already contained in the 'centers' argument, we ask the user to pass it explicitly so that various checks on the arguments may be conducted.
+   *  \param[in] n_basis_functions_per_dim  Number of basis functions
+   *  \param[in] intersection_height The value at which two neighbouring basis functions will intersect.
+   * \param[in] asymmetric_kernels Whether to use asymmetric kernels or not (to be documented, default is false)
+   *
+   *  The centers and widths of the basis functions are determined from these parameters once the
+   *  range of the input data is known, see also setInputMinMax()
+   */
+  MetaParametersLWR(int expected_input_dim, const Eigen::VectorXi& n_basis_functions_per_dim, double intersection_height=0.5, bool asymmetric_kernels=false);
+  
+  
+  /** Constructor for the algorithmic meta-parameters of the LWR function approximator.
+   * This is for the special case when the dimensionality of the input data is 1.
+   *  \param[in] expected_input_dim         The dimensionality of the data this function approximator expects. Since this constructor is for 1-D input data only, we simply check if this argument is equal to 1.
+   *  \param[in] n_basis_functions  Number of basis functions for the one dimension
+   *  \param[in] intersection_height The value at which two neighbouring basis functions will intersect.
+   * \param[in] asymmetric_kernels Whether to use asymmetric kernels or not (to be documented, default is false)
+   *
+   *  The centers and widths of the basis functions are determined from these parameters once the
+   *  range of the input data is known, see also setInputMinMax()
+   */
+	MetaParametersLWR(int expected_input_dim, int n_basis_functions=10, double intersection_height=0.5, bool asymmetric_kernels=false);
+
+	/** Get the centers and widths of the basis functions.
+	 *  \param[in] min Minimum values of input data (one value for each dimension).
+	 *  \param[in] max Maximum values of input data (one value for each dimension).
+	 *  \param[out] centers Centers of the basis functions (matrix of size n_basis_functions X n_input_dims
+	 *  \param[out] widths Widths of the basis functions (matrix of size n_basis_functions X n_input_dims
+	 *
+	 * The reason why there are not two functions getCenters and getWidths is that it is much easier
+	 * to compute both at the same time, and usually you will need both at the same time anyway.
+	 */
+	void getCentersAndWidths(const Eigen::VectorXd& min, const Eigen::VectorXd& max, Eigen::MatrixXd& centers, Eigen::MatrixXd& widths) const;
+	
+	/** Accessor function for asymmetric_kernels.
+	 * \return true if asymmetric kernels are used, false if symmetric kernels are used.
+	 * \todo Document this. In the literature, only symmetric kernels are used.
+	 */
+  bool asymmetric_kernels(void) const
+  {
+    return asymmetric_kernels_;
+  }
+
+	MetaParametersLWR* clone(void) const;
+
+	std::string toString(void) const;
+
+private:
+  Eigen::VectorXi n_bfs_per_dim_; // should be const
+  std::vector<Eigen::VectorXd> centers_per_dim_; // should be const
+  double intersection_height_; // should be const
+  bool asymmetric_kernels_; // should be const
+
+  /**
+   * Default constructor.
+   * \remarks This default constuctor is required for boost::serialization to work. Since this
+   * constructor should not be called by other classes, it is private (boost::serialization is a
+   * friend)
+   */
+  MetaParametersLWR(void) {}; 
+  
+  /** Give boost serialization access to private members. */  
+  friend class boost::serialization::access;
+  
+  /** Serialize class data members to boost archive. 
+   * \param[in] ar Boost archive
+   * \param[in] version Version of the class
+   * See http://www.boost.org/doc/libs/1_55_0/libs/serialization/doc/tutorial.html#simplecase
+   */
+  template<class Archive>
+  void serialize(Archive & ar, const unsigned int version);
+
+};
+
+}
+
+#include <boost/serialization/export.hpp>
+/** Register this derived class. */
+BOOST_CLASS_EXPORT_KEY2(DmpBbo::MetaParametersLWR, "MetaParametersLWR")
+
+/** Don't add version information to archives. */
+BOOST_CLASS_IMPLEMENTATION(DmpBbo::MetaParametersLWR,boost::serialization::object_serializable);
+
+#endif        //  #ifndef METAPARAMETERSLWR_H
+

--- a/src/functionapproximators/ModelParametersLWR.cpp
+++ b/src/functionapproximators/ModelParametersLWR.cpp
@@ -20,7 +20,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
  */
- 
+#define EIGEN2_SUPPORT 
 #include <boost/serialization/export.hpp>
 #include <boost/archive/text_iarchive.hpp>
 #include <boost/archive/text_oarchive.hpp>

--- a/src/functionapproximators/ModelParametersLWR.cpp~
+++ b/src/functionapproximators/ModelParametersLWR.cpp~
@@ -1,0 +1,555 @@
+/**
+ * @file   ModelParametersLWR.cpp
+ * @brief  ModelParametersLWR class source file.
+ * @author Freek Stulp
+ *
+ * This file is part of DmpBbo, a set of libraries and programs for the 
+ * black-box optimization of dynamical movement primitives.
+ * Copyright (C) 2014 Freek Stulp, ENSTA-ParisTech
+ * 
+ * DmpBbo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ * 
+ * DmpBbo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
+#include <boost/serialization/export.hpp>
+#include <boost/archive/text_iarchive.hpp>
+#include <boost/archive/text_oarchive.hpp>
+#include <boost/archive/xml_iarchive.hpp>
+#include <boost/archive/xml_oarchive.hpp>
+#include "functionapproximators/ModelParametersLWR.hpp"
+
+BOOST_CLASS_EXPORT_IMPLEMENT(DmpBbo::ModelParametersLWR);
+
+#include "dmpbbo_io/EigenFileIO.hpp"
+#include "dmpbbo_io/BoostSerializationToString.hpp"
+#include "dmpbbo_io/EigenBoostSerialization.hpp"
+
+#include <iostream>
+#include <fstream>
+
+#include <eigen3/Eigen/Core>
+
+
+using namespace std;
+using namespace Eigen;
+
+namespace DmpBbo {
+
+ModelParametersLWR::ModelParametersLWR(const MatrixXd& centers, const MatrixXd& widths, const MatrixXd& slopes, const MatrixXd& offsets, bool asymmetric_kernels, bool lines_pivot_at_max_activation) 
+:
+  centers_(centers),
+  widths_(widths),
+  slopes_(slopes), 
+  offsets_(offsets),
+  asymmetric_kernels_(asymmetric_kernels),
+  lines_pivot_at_max_activation_(lines_pivot_at_max_activation),
+  slopes_as_angles_(false),
+  caching_(true)
+{
+#ifndef NDEBUG // Variables below are only required for asserts; check for NDEBUG to avoid warnings.
+  int n_basis_functions = centers.rows();
+  int n_dims = centers.cols();
+#endif  
+  assert(n_basis_functions==widths_.rows());
+  assert(n_dims           ==widths_.cols());
+  assert(n_basis_functions==slopes_.rows());
+  assert(n_dims           ==slopes_.cols());
+  assert(n_basis_functions==offsets_.rows());
+  assert(1                ==offsets_.cols());
+  
+  all_values_vector_size_ = 0;
+  all_values_vector_size_ += centers_.rows()*centers_.cols();
+  all_values_vector_size_ += widths_.rows() *widths_.cols();
+  all_values_vector_size_ += offsets_.rows()*offsets_.cols();
+  all_values_vector_size_ += slopes_.rows() *slopes_.cols();
+
+};
+
+ModelParameters* ModelParametersLWR::clone(void) const {
+  return new ModelParametersLWR(centers_,widths_,slopes_,offsets_,asymmetric_kernels_,lines_pivot_at_max_activation_); 
+}
+
+void ModelParametersLWR::kernelActivations(const MatrixXd& inputs, MatrixXd& kernel_activations) const
+{
+  kernelActivations(centers_,widths_,inputs,kernel_activations,asymmetric_kernels_);  
+}
+
+void ModelParametersLWR::normalizedKernelActivations(const MatrixXd& inputs, MatrixXd& normalized_kernel_activations) const
+{
+  if (caching_)
+  {
+    // If the cached inputs matrix has the same size as the one now requested
+    //     (this also takes care of the case when inputs_cached is empty and need to be initialized)
+    if ( inputs.rows()==inputs_cached_.rows() && inputs.cols()==inputs_cached_.cols() )
+    {
+      // And they have the same values
+      if ( (inputs.array()==inputs_cached_.array()).all() )
+      {
+        // Then you can return the cached values
+        normalized_kernel_activations = normalized_kernel_activations_cached_;
+        return;
+      }
+    }
+  }
+
+  // Cache could not be used, actually do the work
+  normalizedKernelActivations(centers_,widths_,inputs,normalized_kernel_activations,asymmetric_kernels_);
+
+  if (caching_)
+  {
+    // Cache the current results now.  
+    inputs_cached_ = inputs;
+    normalized_kernel_activations_cached_ = normalized_kernel_activations;
+  }
+  
+}
+
+void ModelParametersLWR::set_lines_pivot_at_max_activation(bool lines_pivot_at_max_activation)
+{
+  // If no change, just return
+  if (lines_pivot_at_max_activation_ == lines_pivot_at_max_activation)
+    return;
+
+  //cout << "________________" << endl;
+  //cout << centers_.transpose() << endl;  
+  //cout << slopes_.transpose() << endl;  
+  //cout << offsets_.transpose() << endl;  
+  //cout << "centers_ = " << centers_.rows() << "X" << centers_.cols() << endl;
+  //cout << "slopes_ = " << slopes_.rows() << "X" << slopes_.cols() << endl;
+  //cout << "offsets_ = " << offsets_.rows() << "X" << offsets_.cols() << endl;
+
+  // If you pivot lines around the point when the basis function has maximum activation (i.e.
+  // at the center of the Gaussian), you must compute the new offset corresponding to this
+  // slope, and vice versa    
+  int n_lines = centers_.rows();
+  VectorXd ac(n_lines); // slopes*centers
+  for (int i_line=0; i_line<n_lines; i_line++)
+  {
+    ac[i_line] = slopes_.row(i_line) * centers_.row(i_line).transpose();
+  }
+    
+  if (lines_pivot_at_max_activation)
+  {
+    // Representation was "y = ax + b", now it will be "y = a(x-c) + b^new" 
+    // Since "y = ax + b" can be rewritten as "y = a(x-c) + (b+ac)", we know that "b^new = (ac+b)"
+    offsets_ = offsets_ + ac;
+  }
+  else
+  {
+    // Representation was "y = a(x-c) + b", now it will be "y = ax + b^new" 
+    // Since "y = a(x-c) + b" can be rewritten as "y = ax + (b-ac)", we know that "b^new = (b-ac)"
+    offsets_ = offsets_ - ac;
+  } 
+  // Remark, the above could have been done as a one-liner, but I prefer the more legible version.
+  
+  //cout << offsets_.transpose() << endl;  
+  //cout << "offsets_ = " << offsets_.rows() << "X" << offsets_.cols() << endl;
+  
+  lines_pivot_at_max_activation_ = lines_pivot_at_max_activation;
+}
+
+void ModelParametersLWR::set_slopes_as_angles(bool slopes_as_angles)
+{
+  slopes_as_angles_ = slopes_as_angles;
+  cerr << __FILE__ << ":" << __LINE__ << ":";
+  cerr << "Not implemented yet!!!" << endl;
+  slopes_as_angles_ = false;
+}
+
+
+
+
+void ModelParametersLWR::getLines(const MatrixXd& inputs, MatrixXd& lines) const
+{
+  int n_time_steps = inputs.rows();
+
+  //cout << "centers_ = " << centers_.rows() << "X" << centers_.cols() << endl;
+  //cout << "slopes_ = " << slopes_.rows() << "X" << slopes_.cols() << endl;
+  //cout << "offsets_ = " << offsets_.rows() << "X" << offsets_.cols() << endl;
+  //cout << "inputs = " << inputs.rows() << "X" << inputs.cols() << endl;
+  
+  // Compute values along lines for each time step  
+  // Line representation is "y = ax + b"
+  lines = inputs*slopes_.transpose() + offsets_.transpose().replicate(n_time_steps,1);
+  
+  if (lines_pivot_at_max_activation_)
+  {
+    // Line representation is "y = a(x-c) + b", which is  "y = ax - ac + b"
+    // Therefore, we still have to subtract "ac"
+    int n_lines = centers_.rows();
+    VectorXd ac(n_lines); // slopes*centers  = ac
+    for (int i_line=0; i_line<n_lines; i_line++)
+      ac[i_line] = slopes_.row(i_line) * centers_.row(i_line).transpose();
+    //cout << "ac = " << ac.rows() << "X" << ac.cols() << endl;
+    lines = lines - ac.transpose().replicate(n_time_steps,1);
+  }
+  //cout << "lines = " << lines.rows() << "X" << lines.cols() << endl;
+}
+  
+void ModelParametersLWR::locallyWeightedLines(const MatrixXd& inputs, MatrixXd& output) const
+{
+  
+  MatrixXd lines;
+  getLines(inputs, lines);
+
+  // Weight the values for each line with the normalized basis function activations  
+  MatrixXd activations;
+  normalizedKernelActivations(inputs,activations);
+  
+  output = (lines.array()*activations.array()).rowwise().sum();
+}
+
+/*
+void ModelParametersLWR::kernelActivationsSymmetric(const MatrixXd& centers, const MatrixXd& widths, const MatrixXd& inputs, MatrixXd& kernel_activations)
+{
+  cout << __FILE__ << ":" << __LINE__ << ":Here" << endl;
+  // Check and set sizes
+  // centers     = n_basis_functions x n_dim
+  // widths      = n_basis_functions x n_dim
+  // inputs      = n_samples         x n_dim
+  // activations = n_samples         x n_basis_functions
+  int n_basis_functions = centers.rows();
+  int n_samples         = inputs.rows();
+  int n_dims            = centers.cols();
+  assert( (n_basis_functions==widths.rows()) & (n_dims==widths.cols()) ); 
+  assert( (n_samples==inputs.rows()        ) & (n_dims==inputs.cols()) ); 
+  kernel_activations.resize(n_samples,n_basis_functions);  
+
+
+  VectorXd center, width;
+  for (int bb=0; bb<n_basis_functions; bb++)
+  {
+    center = centers.row(bb);
+    width  = widths.row(bb);
+
+    // Here, we compute the values of a (unnormalized) multi-variate Gaussian:
+    //   activation = exp(-0.5*(x-mu)*Sigma^-1*(x-mu))
+    // Because Sigma is diagonal in our case, this simplifies to
+    //   activation = exp(\sum_d=1^D [-0.5*(x_d-mu_d)^2/Sigma_(d,d)]) 
+    //              = \prod_d=1^D exp(-0.5*(x_d-mu_d)^2/Sigma_(d,d)) 
+    // This last product is what we compute below incrementally
+    
+    kernel_activations.col(bb).fill(1.0);
+    for (int i_dim=0; i_dim<n_dims; i_dim++)
+    {
+      kernel_activations.col(bb).array() *= exp(-0.5*pow(inputs.col(i_dim).array()-center[i_dim],2)/(width[i_dim]*width[i_dim])).array();
+    }
+  }
+}
+*/
+
+void ModelParametersLWR::kernelActivations(const MatrixXd& centers, const MatrixXd& widths, const MatrixXd& inputs, MatrixXd& kernel_activations, bool asymmetric_kernels)
+{
+  
+  // Check and set sizes
+  // centers     = n_basis_functions x n_dim
+  // widths      = n_basis_functions x n_dim
+  // inputs      = n_samples         x n_dim
+  // activations = n_samples         x n_basis_functions
+  int n_basis_functions = centers.rows();
+  int n_samples         = inputs.rows();
+  int n_dims            = centers.cols();
+  assert( (n_basis_functions==widths.rows()) & (n_dims==widths.cols()) ); 
+  assert( (n_samples==inputs.rows()        ) & (n_dims==inputs.cols()) ); 
+  kernel_activations.resize(n_samples,n_basis_functions);  
+
+  double c,w,x;
+  for (int bb=0; bb<n_basis_functions; bb++)
+  {
+
+    // Here, we compute the values of a (unnormalized) multi-variate Gaussian:
+    //   activation = exp(-0.5*(x-mu)*Sigma^-1*(x-mu))
+    // Because Sigma is diagonal in our case, this simplifies to
+    //   activation = exp(\sum_d=1^D [-0.5*(x_d-mu_d)^2/Sigma_(d,d)]) 
+    //              = \prod_d=1^D exp(-0.5*(x_d-mu_d)^2/Sigma_(d,d)) 
+    // This last product is what we compute below incrementally
+    
+    kernel_activations.col(bb).fill(1.0);
+    for (int i_dim=0; i_dim<n_dims; i_dim++)
+    {
+      c = centers(bb,i_dim);
+      for (int i_s=0; i_s<n_samples; i_s++)
+      {
+        x = inputs(i_s,i_dim);
+        w = widths(bb,i_dim);
+        
+        if (asymmetric_kernels && x<c && bb>0)
+          // Get the width of the previous basis function
+          // This is the part that makes it assymetric
+          w = widths(bb-1,i_dim);
+          
+        kernel_activations(i_s,bb) *= exp(-0.5*pow(x-c,2)/(w*w));
+      }
+    }
+  }
+}
+
+void ModelParametersLWR::normalizedKernelActivations(const MatrixXd& centers, const MatrixXd& widths, const MatrixXd& inputs, MatrixXd& normalized_kernel_activations, bool asymmetric_kernels)
+{
+
+  // centers     = n_basis_functions x n_dim
+  // widths      = n_basis_functions x n_dim
+  // inputs      = n_samples         x n_dim
+  // activations = n_samples         x n_basis_functions
+  int n_basis_functions = centers.rows();
+  int n_samples         = inputs.rows();
+  normalized_kernel_activations.resize(n_samples,n_basis_functions);  
+  
+  if (n_basis_functions==1)
+  {
+    // Locally Weighted Regression with only one basis function is pretty odd.
+    // Essentially, you are taking the "Locally Weighted" part out of the regression, and it becomes
+    // standard least squares 
+    // Anyhow, for those that still want to "abuse" LWR as R (i.e. without LW), we explicitly
+    // set the normalized kernels to 1 here, to avoid numerical issues in the normalization below.
+    // (normalizing a Gaussian basis function with itself leads to 1 everywhere).
+    normalized_kernel_activations.fill(1.0);
+    return;
+  }  
+
+  // Get activations of kernels
+  // Note that these are not normalized yet, even though they are called
+  // 'normalized_kernel_activations'. This is just to save allocating extra memory.
+  kernelActivations(centers,widths,inputs,normalized_kernel_activations,asymmetric_kernels);
+  
+  // Compute sum for each row (each value in input_vector)
+  MatrixXd sum_kernel_activations = normalized_kernel_activations.rowwise().sum(); // n_samples x 1
+
+  // Add small number to avoid division by zero. Not full-proof...  
+  if ((sum_kernel_activations.array()==0).any())
+    sum_kernel_activations.array() += sum_kernel_activations.maxCoeff()/100000.0;
+  
+  // Normalize for each row (each value in input_vector)  
+  normalized_kernel_activations = normalized_kernel_activations.array()/sum_kernel_activations.replicate(1,n_basis_functions).array();
+}
+
+template<class Archive>
+void ModelParametersLWR::serialize(Archive & ar, const unsigned int version)
+{
+  // serialize base class information
+  ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(ModelParameters);
+
+  ar & BOOST_SERIALIZATION_NVP(centers_);
+  ar & BOOST_SERIALIZATION_NVP(widths_);
+  ar & BOOST_SERIALIZATION_NVP(slopes_);
+  ar & BOOST_SERIALIZATION_NVP(offsets_);
+  ar & BOOST_SERIALIZATION_NVP(asymmetric_kernels_);
+  ar & BOOST_SERIALIZATION_NVP(lines_pivot_at_max_activation_);
+  ar & BOOST_SERIALIZATION_NVP(slopes_as_angles_);
+  ar & BOOST_SERIALIZATION_NVP(all_values_vector_size_);
+  ar & BOOST_SERIALIZATION_NVP(caching_);
+}
+
+string ModelParametersLWR::toString(void) const
+{
+  RETURN_STRING_FROM_BOOST_SERIALIZATION_XML("ModelParametersLWR");
+}
+
+void ModelParametersLWR::getSelectableParameters(set<string>& selected_values_labels) const 
+{
+  selected_values_labels = set<string>();
+  selected_values_labels.insert("centers");
+  selected_values_labels.insert("widths");
+  selected_values_labels.insert("offsets");
+  selected_values_labels.insert("slopes");
+}
+
+
+void ModelParametersLWR::getParameterVectorMask(const std::set<std::string> selected_values_labels, VectorXi& selected_mask) const
+{
+
+  selected_mask.resize(getParameterVectorAllSize());
+  selected_mask.fill(0);
+  
+  int offset = 0;
+  int size;
+  
+  // Centers
+  size = centers_.rows()*centers_.cols();
+  if (selected_values_labels.find("centers")!=selected_values_labels.end())
+    selected_mask.segment(offset,size).fill(1);
+  offset += size;
+  
+  // Widths
+  size = widths_.rows()*widths_.cols();
+  if (selected_values_labels.find("widths")!=selected_values_labels.end())
+    selected_mask.segment(offset,size).fill(2);
+  offset += size;
+  
+  // Offsets
+  size = offsets_.rows()*offsets_.cols();
+  if (selected_values_labels.find("offsets")!=selected_values_labels.end())
+    selected_mask.segment(offset,size).fill(3);
+  offset += size;
+
+  // Slopes
+  size = slopes_.rows()*slopes_.cols();
+  if (selected_values_labels.find("slopes")!=selected_values_labels.end())
+    selected_mask.segment(offset,size).fill(4);
+  offset += size;
+
+  assert(offset == getParameterVectorAllSize());   
+}
+
+void ModelParametersLWR::getParameterVectorAll(VectorXd& values) const
+{
+  values.resize(getParameterVectorAllSize());
+  int offset = 0;
+  
+  for (int i_dim=0; i_dim<centers_.cols(); i_dim++)
+  {
+    values.segment(offset,centers_.rows()) = centers_.col(i_dim);
+    offset += centers_.rows();
+  }
+  
+  for (int i_dim=0; i_dim<widths_.cols(); i_dim++)
+  {
+    values.segment(offset,widths_.rows()) = widths_.col(i_dim);
+    offset += widths_.rows();
+  }
+  
+  values.segment(offset,offsets_.rows()) = offsets_;
+  offset += offsets_.rows();
+  
+  VectorXd cur_slopes;
+  for (int i_dim=0; i_dim<slopes_.cols(); i_dim++)
+  {
+    cur_slopes = slopes_.col(i_dim);
+    if (slopes_as_angles_)
+    {
+      // cur_slopes is a slope, but the values vector expects the angle with the x-axis. Do the 
+      // conversion here.
+      for (int ii=0; ii<cur_slopes.size(); ii++)
+        cur_slopes[ii] = atan2(cur_slopes[ii],1.0);
+    }
+    
+    values.segment(offset,slopes_.rows()) = cur_slopes;
+    offset += slopes_.rows();
+  }
+  
+  assert(offset == getParameterVectorAllSize());   
+};
+
+void ModelParametersLWR::setParameterVectorAll(const VectorXd& values) {
+
+  if (all_values_vector_size_ != values.size())
+  {
+    cerr << __FILE__ << ":" << __LINE__ << ": values is of wrong size." << endl;
+    return;
+  }
+  
+  int offset = 0;
+  int size = centers_.rows();
+  int n_dims = centers_.cols();
+  for (int i_dim=0; i_dim<n_dims; i_dim++)
+  {
+    // If the centers change, the cache for normalizedKernelActivations() must be cleared,
+    // because this function will return different values for different centers
+    if ( !(centers_.col(i_dim).array() == values.segment(offset,size).array()).all() )
+      clearCache();
+    
+    centers_.col(i_dim) = values.segment(offset,size);
+    offset += size;
+  }
+  for (int i_dim=0; i_dim<n_dims; i_dim++)
+  {
+    // If the centers change, the cache for normalizedKernelActivations() must be cleared,
+    // because this function will return different values for different centers
+    if ( !(widths_.col(i_dim).array() == values.segment(offset,size).array()).all() )
+      clearCache();
+    
+    widths_.col(i_dim) = values.segment(offset,size);
+    offset += size;
+  }
+
+  offsets_ = values.segment(offset,size);
+  offset += size;
+  // Cache must not be cleared, because normalizedKernelActivations() returns the same values.
+
+  MatrixXd old_slopes = slopes_;
+  for (int i_dim=0; i_dim<n_dims; i_dim++)
+  {
+    slopes_.col(i_dim) = values.segment(offset,size);
+    offset += size;
+    // Cache must not be cleared, because normalizedKernelActivations() returns the same values.
+  }
+
+  assert(offset == getParameterVectorAllSize());   
+};
+
+bool ModelParametersLWR::saveGridData(const VectorXd& min, const VectorXd& max, const VectorXi& n_samples_per_dim, string save_directory, bool overwrite) const
+{
+  if (save_directory.empty())
+    return true;
+  
+  //cout << "        Saving LWR model grid data to: " << save_directory << "." << endl;
+  
+  int n_dims = min.size();
+  assert(n_dims==max.size());
+  assert(n_dims==n_samples_per_dim.size());
+  
+  MatrixXd inputs;
+  if (n_dims==1)
+  {
+    inputs  = VectorXd::LinSpaced(n_samples_per_dim[0], min[0], max[0]);
+  }
+  else if (n_dims==2)
+  {
+    int n_samples = n_samples_per_dim[0]*n_samples_per_dim[1];
+    inputs = MatrixXd::Zero(n_samples, n_dims);
+    VectorXd x1 = VectorXd::LinSpaced(n_samples_per_dim[0], min[0], max[0]);
+    VectorXd x2 = VectorXd::LinSpaced(n_samples_per_dim[1], min[1], max[1]);
+    for (int ii=0; ii<x1.size(); ii++)
+    {
+      for (int jj=0; jj<x2.size(); jj++)
+      {
+        inputs(ii*x2.size()+jj,0) = x1[ii];
+        inputs(ii*x2.size()+jj,1) = x2[jj];
+      }
+    }
+  }  
+      
+  MatrixXd lines;
+  getLines(inputs, lines);
+  
+  MatrixXd weighted_lines;
+  locallyWeightedLines(inputs, weighted_lines);
+  
+  MatrixXd activations;
+  kernelActivations(inputs, activations);
+    
+  MatrixXd normalized_activations;
+  normalizedKernelActivations(inputs, normalized_activations);
+    
+  saveMatrix(save_directory,"n_samples_per_dim.txt",n_samples_per_dim,overwrite);
+  saveMatrix(save_directory,"inputs_grid.txt",inputs,overwrite);
+  saveMatrix(save_directory,"lines.txt",lines,overwrite);
+  saveMatrix(save_directory,"weighted_lines.txt",weighted_lines,overwrite);
+  saveMatrix(save_directory,"activations.txt",activations,overwrite);
+  saveMatrix(save_directory,"activations_normalized.txt",normalized_activations,overwrite);
+  
+  return true;
+  
+}
+
+void ModelParametersLWR::setParameterVectorModifierPrivate(std::string modifier, bool new_value)
+{
+  if (modifier.compare("lines_pivot_at_max_activation")==0)
+    set_lines_pivot_at_max_activation(new_value);
+  
+  if (modifier.compare("slopes_as_angles")==0)
+    set_slopes_as_angles(new_value);
+  
+}
+
+}

--- a/src/functionapproximators/ModelParametersLWR.hpp
+++ b/src/functionapproximators/ModelParametersLWR.hpp
@@ -23,7 +23,7 @@
  
 #ifndef MODELPARAMETERSLWR_H
 #define MODELPARAMETERSLWR_H
-
+#define EIGEN2_SUPPORT
 #include "functionapproximators/ModelParameters.hpp"
 
 #include <iosfwd>

--- a/src/functionapproximators/ModelParametersLWR.hpp~
+++ b/src/functionapproximators/ModelParametersLWR.hpp~
@@ -1,0 +1,201 @@
+/**
+ * @file   ModelParametersLWR.hpp
+ * @brief  ModelParametersLWR class header file.
+ * @author Freek Stulp
+ *
+ * This file is part of DmpBbo, a set of libraries and programs for the 
+ * black-box optimization of dynamical movement primitives.
+ * Copyright (C) 2014 Freek Stulp, ENSTA-ParisTech
+ * 
+ * DmpBbo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ * 
+ * DmpBbo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+ 
+#ifndef MODELPARAMETERSLWR_H
+#define MODELPARAMETERSLWR_H
+
+#include "functionapproximators/ModelParameters.hpp"
+
+#include <iosfwd>
+#include <vector>
+
+#include <eigen3/Eigen/Core>
+
+namespace DmpBbo {
+
+/** \brief Model parameters for the Locally Weighted Regression (LWR) function approximator
+ * \ingroup FunctionApproximators
+ * \ingroup LWR
+ */
+class ModelParametersLWR : public ModelParameters
+{
+  friend class FunctionApproximatorLWR;
+  
+public:
+  /** Constructor for the model parameters of the LWPR function approximator.
+   *  \param[in] centers Centers of the basis functions
+   *  \param[in] widths  Widths of the basis functions. 
+   *  \param[in] slopes  Slopes of the line segments. 
+   *  \param[in] offsets Offsets of the line segments, i.e. the value of the line segment at its intersection with the y-axis.
+   * \param[in] asymmetric_kernels Whether to use asymmetric kernels or not, cf MetaParametersLWR::asymmetric_kernels()
+   * \param[in] lines_pivot_at_max_activation Whether line models should pivot at x=0 (false), or at the center of the kernel (x=x_c)
+   */
+  ModelParametersLWR(const Eigen::MatrixXd& centers, const Eigen::MatrixXd& widths, const Eigen::MatrixXd& slopes, const Eigen::MatrixXd& offsets, bool asymmetric_kernels=false, bool lines_pivot_at_max_activation=false);
+  
+  std::string toString(void) const;
+  
+	ModelParameters* clone(void) const;
+	
+  int getExpectedInputDim(void) const  {
+    return centers_.cols();
+  };
+  
+  /** Get the kernel activations for given centers, widths and inputs
+   * \param[in] centers The center of the basis function (size: n_basis_functions X n_dims)
+   * \param[in] widths The width of the basis function (size: n_basis_functions X n_dims)
+   * \param[in] inputs The input data (size: n_samples X n_dims)
+   * \param[out] kernel_activations The kernel activations, computed for each of the samples in the input data (size: n_samples X n_basis_functions)
+   * \param[in] asymmetric_kernels Whether to use asymmetric kernels or not, cf MetaParametersLWR::asymmetric_kernels()
+   */
+  static void kernelActivations(const Eigen::MatrixXd& centers, const Eigen::MatrixXd& widths, const Eigen::MatrixXd& inputs, Eigen::MatrixXd& kernel_activations, bool asymmetric_kernels=false);
+  
+  /** Get the normalized kernel activations for given centers, widths and inputs
+   * \param[in] centers The centers of the basis functions (size: n_basis_functions X n_dims)
+   * \param[in] widths The widths of the basis functions (size: n_basis_functions X n_dims)
+   * \param[in] inputs The input data (size: n_samples X n_dims)
+   * \param[out] normalized_kernel_activations The normalized kernel activations, computed for each of the sampels in the input data (size: n_samples X n_basis_functions)
+   * \param[in] asymmetric_kernels Whether to use asymmetric kernels or not, cf MetaParametersLWR::asymmetric_kernels()
+   */
+  static void normalizedKernelActivations(const Eigen::MatrixXd& centers, const Eigen::MatrixXd& widths, const Eigen::MatrixXd& inputs, Eigen::MatrixXd& normalized_kernel_activations, bool asymmetric_kernels=false);
+	
+  /** Get the kernel activations for given inputs
+   * \param[in] inputs The input data (size: n_samples X n_dims)
+   * \param[out] kernel_activations The kernel activations, computed for each of the samples in the input data (size: n_samples X n_basis_functions)
+   */
+  void kernelActivations(const Eigen::MatrixXd& inputs, Eigen::MatrixXd& kernel_activations) const;
+
+  /** Get the normalized kernel activations for given inputs
+   * \param[in] inputs The input data (size: n_samples X n_dims)
+   * \param[out] normalized_kernel_activations The normalized kernel activations, computed for each of the sampels in the input data (size: n_samples X n_basis_functions)
+   */
+  void normalizedKernelActivations(const Eigen::MatrixXd& inputs, Eigen::MatrixXd& normalized_kernel_activations) const;
+  
+  /** Get the output of each linear model (unweighted) for the given inputs.
+   * \param[in] inputs The inputs for which to compute the output of the lines models (size: n_samples X  n_input_dims)
+   * \param[out] lines The output of the linear models (size: n_samples X n_output_dim) 
+   */
+  void getLines(const Eigen::MatrixXd& inputs, Eigen::MatrixXd& lines) const;
+  
+  /** Compute the sum of the locally weighted lines. 
+   * \param[in] inputs The inputs for which to compute the output (size: n_samples X  n_input_dims)
+   * \param[out] output The weighted linear models (size: n_samples X n_output_dim) 
+   *
+   */
+  void locallyWeightedLines(const Eigen::MatrixXd& inputs, Eigen::MatrixXd& output) const;
+  
+  void setParameterVectorModifierPrivate(std::string modifier, bool new_value);
+  
+  /** Set whether the offsets should be adapted so that the line segments pivot around the mode of
+   * the basis function, rather than the intersection with the y-axis.
+   * \param[in] lines_pivot_at_max_activation Whether to pivot around the mode or not.
+   *
+   */
+  void set_lines_pivot_at_max_activation(bool lines_pivot_at_max_activation);
+
+  /** Whether to return slopes as angles or slopes in ModelParametersLWR::getParameterVectorAll()
+   * \param[in] slopes_as_angles Whether to return as slopes (true) or angles (false)
+   * \todo Implement and document
+   */
+  void set_slopes_as_angles(bool slopes_as_angles);
+  
+  void getSelectableParameters(std::set<std::string>& selected_values_labels) const;
+  void getParameterVectorMask(const std::set<std::string> selected_values_labels, Eigen::VectorXi& selected_mask) const;
+  void getParameterVectorAll(Eigen::VectorXd& all_values) const;
+  inline int getParameterVectorAllSize(void) const
+  {
+    return all_values_vector_size_;
+  }
+  
+	bool saveGridData(const Eigen::VectorXd& min, const Eigen::VectorXd& max, const Eigen::VectorXi& n_samples_per_dim, std::string directory, bool overwrite=false) const;
+
+protected:
+  void setParameterVectorAll(const Eigen::VectorXd& values);
+  
+private:
+  Eigen::MatrixXd centers_; // n_centers X n_dims
+  Eigen::MatrixXd widths_;  // n_centers X n_dims
+  Eigen::MatrixXd slopes_;  // n_centers X n_dims
+  Eigen::VectorXd offsets_; //         1 X n_dims
+
+  bool asymmetric_kernels_; // should be const
+  bool lines_pivot_at_max_activation_;
+  bool slopes_as_angles_;
+  int  all_values_vector_size_;
+
+public:
+	/** Turn caching for the function normalizedKernelActivations() on or off.
+	 * Turning this on should lead to substantial improvements in execution time if the centers and
+	 * widths of the kernels do not change often AND you call normalizedKernelActivations with the
+	 * same inputs over and over again.
+	 * \param[in] caching Whether to turn caching on or off
+	 * \remarks In the constructor, caching is set to true, so by default it is on.
+	 */
+	inline void set_caching(bool caching)
+	{
+	  caching_ = caching;
+	  if (!caching_) clearCache();
+	}
+	
+private:
+  
+  mutable Eigen::MatrixXd inputs_cached_;
+  mutable Eigen::MatrixXd normalized_kernel_activations_cached_;
+  bool caching_;
+  inline void clearCache(void) 
+  {
+    inputs_cached_.resize(0,0);
+    normalized_kernel_activations_cached_.resize(0,0);
+  }
+  
+  /**
+   * Default constructor.
+   * \remarks This default constuctor is required for boost::serialization to work. Since this
+   * constructor should not be called by other classes, it is private (boost::serialization is a
+   * friend)
+   */
+  ModelParametersLWR(void) {};
+
+  /** Give boost serialization access to private members. */  
+  friend class boost::serialization::access;
+  
+  /** Serialize class data members to boost archive. 
+   * \param[in] ar Boost archive
+   * \param[in] version Version of the class
+   * See http://www.boost.org/doc/libs/1_55_0/libs/serialization/doc/tutorial.html#simplecase
+   */
+  template<class Archive>
+  void serialize(Archive & ar, const unsigned int version);
+
+};
+
+}
+
+#include <boost/serialization/export.hpp>
+/** Register this derived class. */
+BOOST_CLASS_EXPORT_KEY2(DmpBbo::ModelParametersLWR, "ModelParametersLWR")
+
+/** Don't add version information to archives. */
+BOOST_CLASS_IMPLEMENTATION(DmpBbo::ModelParametersLWR,boost::serialization::object_serializable);
+
+#endif        //  #ifndef MODELPARAMETERSLWR_H
+

--- a/src/functionapproximators/Parameterizable.cpp
+++ b/src/functionapproximators/Parameterizable.cpp
@@ -20,7 +20,7 @@
  * You should have received a copy of the GNU Lesser General Public License
  * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
  */
-
+#define EIGEN2_SUPPORT
 #include "functionapproximators/Parameterizable.hpp"
 
 #include <iostream>

--- a/src/functionapproximators/Parameterizable.cpp~
+++ b/src/functionapproximators/Parameterizable.cpp~
@@ -1,0 +1,303 @@
+/**
+ * @file   Parameterizable.cpp
+ * @brief  Parameterizable class source file.
+ * @author Freek Stulp
+ *
+ * This file is part of DmpBbo, a set of libraries and programs for the 
+ * black-box optimization of dynamical movement primitives.
+ * Copyright (C) 2014 Freek Stulp, ENSTA-ParisTech
+ * 
+ * DmpBbo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ * 
+ * DmpBbo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "functionapproximators/Parameterizable.hpp"
+
+#include <iostream>
+#include <limits>
+#include <eigen3/Eigen/Core>
+
+using namespace std;
+using namespace Eigen;
+
+namespace DmpBbo {
+
+void Parameterizable::setSelectedParameters(const std::set<std::string>& selected_values_labels)
+{
+  getParameterVectorMask(selected_values_labels,selected_mask_);
+}
+
+int Parameterizable::getParameterVectorSelectedSize(void) const
+{  
+  int all_size = 0;
+  for (int all_ii=0; all_ii<selected_mask_.size(); all_ii++)
+    if (selected_mask_[all_ii]>0)
+      all_size++;
+    
+  return all_size;
+}
+
+void Parameterizable::getParameterVectorSelected(Eigen::VectorXd& values, bool normalized) const
+{
+  Eigen::VectorXd all_values;
+  getParameterVectorAll(all_values);
+  
+  values.resize(getParameterVectorSelectedSize());
+  // We cannot do this with Block, because regions might not be contiguous
+  int ii = 0;
+  for (int all_ii=0; all_ii<selected_mask_.size(); all_ii++)
+    if (selected_mask_[all_ii]>0)
+      values[ii++] = all_values[all_ii];
+    
+  if (normalized)
+  {
+    VectorXd min_vec, max_vec;
+    getParameterVectorSelectedMinMax(min_vec, max_vec);
+    
+    VectorXd range =  (max_vec.array()-min_vec.array());
+    for (int ii=0; ii<values.size(); ii++)
+    {
+      if (range[ii]>0)
+      {
+        values[ii] = (values[ii]-min_vec[ii])/range[ii];
+      }
+      else
+      {
+        if (abs(max_vec[ii])>0)
+          values[ii] = values[ii]/abs(2*max_vec[ii]);
+      }
+    }
+    
+  }
+    
+}
+
+
+void Parameterizable::setParameterVectorSelected(const VectorXd& values_arg, bool normalized)
+{
+  // If the initial parameter vector is still empty, get it now, before changing its value.
+  if (parameter_vector_all_initial_.size()==0)
+    getParameterVectorAll(parameter_vector_all_initial_);
+
+  VectorXd all_values;
+  getParameterVectorAll(all_values);
+  
+  VectorXd values = values_arg;
+  if (normalized)
+  {
+    VectorXd min_vec, max_vec, range;
+    getParameterVectorSelectedMinMax(min_vec, max_vec);
+    range =  (max_vec.array()-min_vec.array());
+    for (int ii=0; ii<values.size(); ii++)
+    {
+      if (range[ii]>0)
+      {
+        values[ii] = values[ii]*range[ii] + min_vec[ii];
+      }
+      else
+      {
+        if (abs(max_vec[ii])>0)
+          values[ii] = values[ii]*abs(2*max_vec[ii]);
+      }
+    }
+  }
+  
+  // We cannot do this with Eigen::Block, because regions might not be contiguous
+  int ii = 0;
+  for (int all_ii=0; all_ii<selected_mask_.size(); all_ii++)
+    if (selected_mask_[all_ii]>0)
+      all_values[all_ii] = values[ii++];
+    
+  setParameterVectorAll(all_values);
+  
+}
+
+void Parameterizable::getParameterVectorSelectedMinMax(Eigen::VectorXd& min_vec, Eigen::VectorXd& max_vec) const
+{
+  VectorXd all_min_vec, all_max_vec;
+  getParameterVectorAllMinMax(all_min_vec, all_max_vec);
+  
+  min_vec.resize(getParameterVectorSelectedSize());
+  max_vec.resize(getParameterVectorSelectedSize());
+  
+  // We cannot do this with Eigen::Block, because regions might not be contiguous
+  int ii = 0;
+  for (int all_ii=0; all_ii<selected_mask_.size(); all_ii++)
+  {
+    if (selected_mask_[all_ii]>0)
+    {
+      min_vec[ii] = all_min_vec[all_ii];
+      max_vec[ii] = all_max_vec[all_ii];
+      ii++;
+    }
+  }
+  
+}
+
+void Parameterizable::getParameterVectorAllMinMax(Eigen::VectorXd& min_vec, Eigen::VectorXd& max_vec) const
+{
+  set<string> all_selected_values_labels;
+  getSelectableParameters(all_selected_values_labels);
+  
+  VectorXi selected_mask;
+  getParameterVectorMask(all_selected_values_labels, selected_mask);
+  
+  // If the initial parameter vector is still empty, get it now.
+  if (parameter_vector_all_initial_.size()==0)
+    getParameterVectorAll(parameter_vector_all_initial_);
+  
+  Eigen::VectorXd all_values = parameter_vector_all_initial_;
+  
+  // Example: 
+  // selected_mask = [  1   1   1     2   2   2     3   3   3     1   1    1   ] 
+  // all_values    = [ 1.0 2.0 3.0   4.0 5.0 6.0   7.0 8.0 9.0  20.0 21.0 22.0 ] 
+  //
+  // For all blocks in selected_mask, compute the min/max in all_values for that block.
+  // In the example above
+  //   block 1 : min = 1.0; max = 22.0;
+  //   block 2 : min = 4.0; max =  6.0;
+  //   block 3 : min = 7.0; max =  9.0;
+  //
+  // Then min_vec and max_vec will be as follows:
+  //   min_vec = [ 1.0 1.0 1.0   4.0 4.0 4.0   7.0 7.0 7.0     1.0 1.0 1.0 ]
+  //   max_vec = [ 3.0 3.0 3.0   6.0 6.0 6.0   9.0 9.0 9.0  20.0 21.0 22.0 ]
+  
+  min_vec.resize(getParameterVectorAllSize());
+  max_vec.resize(getParameterVectorAllSize());
+
+  // We cannot do this with Eigen::Block, because regions might not be contiguous
+  int n_blocks = selected_mask.maxCoeff();
+  for (int i_block=1; i_block<=n_blocks; i_block++)
+  {
+    if ((selected_mask.array() == i_block).any())
+    {
+      // Initialize values to extrema 
+      double min_this_block = std::numeric_limits<double>::max();
+      double max_this_block = std::numeric_limits<double>::lowest();
+      
+      // Determine the min/max values in this block
+      for (int all_ii=0; all_ii<selected_mask.size(); all_ii++)
+      {
+        if (selected_mask[all_ii]==i_block)
+        {
+          min_this_block =(all_values[all_ii]<min_this_block ? all_values[all_ii] : min_this_block);
+          max_this_block =(all_values[all_ii]>max_this_block ? all_values[all_ii] : max_this_block);
+        }
+      }
+      
+      // Set the min/max for this block
+      for (int all_ii=0; all_ii<selected_mask.size(); all_ii++)
+      {
+        if (selected_mask[all_ii]==i_block)
+        {
+          min_vec[all_ii] = min_this_block;
+          max_vec[all_ii] = max_this_block;
+        }
+      }
+      
+      //cout << "_________________" << endl;
+      //cout << "  i_block=" << i_block << endl;
+      //cout << "  min_this_block=" << min_this_block << endl;
+      //cout << "  max_this_block=" << max_this_block << endl;
+      //cout << min_vec.transpose() << endl;
+      //cout << max_vec.transpose() << endl;
+    }
+    
+  }
+    
+}
+
+
+/*
+void Parameterizable::getParameterVectorSelectedMinMax(Eigen::VectorXd& min_vec, Eigen::VectorXd& max_vec) const
+{
+
+  Eigen::VectorXd all_min_values, all_max_values;
+  getParameterVectorAllMinMax(all_min_values,all_max_values);
+  
+  min_vec.resize(getParameterVectorSelectedSize());
+  max_vec.resize(getParameterVectorSelectedSize());
+  // We cannot do this with Block, because regions might not be contiguous
+  int ii = 0;
+  for (int all_ii=0; all_ii<selected_mask_.size(); all_ii++)
+  {
+    if (selected_mask_[all_ii]>0)
+    {
+      min_vec[ii] = all_min_values[all_ii];  
+      max_vec[ii] = all_max_values[all_ii];  
+      ii++;
+    }
+  }
+}
+*/
+
+
+void Parameterizable::getParameterVectorSelected(vector<VectorXd>& vector_values, bool normalized) const
+{
+  VectorXd values;
+  getParameterVectorSelected(values,normalized);
+  
+  if (lengths_per_dimension_.size()==0)
+  {
+    vector_values.resize(1);
+    vector_values[0] = values;
+    return;
+  }
+
+  assert(values.size()==lengths_per_dimension_.sum());
+  
+  vector_values.resize(lengths_per_dimension_.size());
+  int offset = 0;
+  for (int i_dim=0; i_dim<lengths_per_dimension_.size(); i_dim++)
+  {
+    vector_values[i_dim] = values.segment(offset,lengths_per_dimension_[i_dim]);
+    offset += lengths_per_dimension_[i_dim];
+  }
+
+}
+
+void Parameterizable::setParameterVectorSelected(const vector<VectorXd>& vector_values, bool normalized)
+{
+  if (lengths_per_dimension_.size()==0)
+  {
+    assert(vector_values.size()==1);
+    assert(vector_values[0].size()==getParameterVectorSelectedSize());
+    setParameterVectorSelected(vector_values[0],normalized);
+    return;
+  }
+  
+  VectorXd values(lengths_per_dimension_.sum());
+  int offset = 0;
+  for (int i_dim=0; i_dim<lengths_per_dimension_.size(); i_dim++)
+  {
+    assert(vector_values[i_dim].size() == lengths_per_dimension_[i_dim]);
+    values.segment(offset,lengths_per_dimension_[i_dim]) = vector_values[i_dim];
+    offset += lengths_per_dimension_[i_dim];
+  }
+  
+  setParameterVectorSelected(values,normalized);
+}
+
+
+void Parameterizable::setParameterVectorModifier(std::string modifier, bool new_value)
+{
+  if (parameter_vector_all_initial_.size()>0)
+  {
+    cerr << __FILE__ << ":" << __LINE__ << ":";
+    cerr << "Warning: you can only set a ParameterVectorModifier if the intial state has not yet been determined." << endl;
+    return;
+  }
+  setParameterVectorModifierPrivate(modifier, new_value);
+}
+
+}

--- a/src/functionapproximators/Parameterizable.hpp
+++ b/src/functionapproximators/Parameterizable.hpp
@@ -23,7 +23,7 @@
 
 #ifndef PARAMETERIZABLE_H
 #define PARAMETERIZABLE_H
-
+#define EIGEN2_SUPPORT
 #include <set>
 #include <string>
 #include <eigen3/Eigen/Core>

--- a/src/functionapproximators/Parameterizable.hpp~
+++ b/src/functionapproximators/Parameterizable.hpp~
@@ -1,0 +1,280 @@
+/**
+ * @file   Parameterizable.hpp
+ * @brief  Parameterizable class header file.
+ * @author Freek Stulp
+ *
+ * This file is part of DmpBbo, a set of libraries and programs for the 
+ * black-box optimization of dynamical movement primitives.
+ * Copyright (C) 2014 Freek Stulp, ENSTA-ParisTech
+ * 
+ * DmpBbo is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ * 
+ * DmpBbo is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ * 
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with DmpBbo.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef PARAMETERIZABLE_H
+#define PARAMETERIZABLE_H
+
+#include <set>
+#include <string>
+#include <eigen3/Eigen/Core>
+
+#include <boost/serialization/nvp.hpp>
+
+namespace DmpBbo {
+
+/** \brief Class for providing access to a model's parameters as a vector.
+ *
+ * Different function approximators have different types of model parameters. For instance, LWR
+ * has the centers and widths of basis functions, along with the slopes of each line segment.
+ * Parameterizable::getValues provides a means to access these parameter as one vector.
+ *
+ * This may be useful for instance when optimizing the model parameters with black-box
+ * optimization, which is agnostic about the semantics of the model parameters. 
+ */
+class Parameterizable {
+  
+public: 
+  /** Get the size of the vector of selected parameters, as returned by getParameterVectorSelected(
+   * \return The size of the vector representation of the selected parameters.
+   */
+  virtual int getParameterVectorSelectedSize(void) const;
+  
+  /**
+   * Get the values of the selected parameters in one vector.
+   * \param[out] values The selected parameters concatenated in one vector
+   * \param[in] normalized Whether to normalize the data or not
+   */
+  virtual void getParameterVectorSelected(Eigen::VectorXd& values, bool normalized=false) const;
+  
+  /**
+   * Get the normalized values of the selected parameters in one vector.
+   * \param[out] values The selected parameters concatenated in one vector
+   */
+  virtual void getParameterVectorSelectedNormalized(Eigen::VectorXd& values) const {
+    getParameterVectorSelected(values, true);
+  }
+
+  /**
+   * Get the minimum and maximum of the selected parameters in one vector.
+   * \param[out] min The minimum of the selected parameters concatenated in one vector
+   * \param[out] max The minimum of the selected parameters concatenated in one vector
+   */
+  void getParameterVectorSelectedMinMax(Eigen::VectorXd& min, Eigen::VectorXd& max) const;
+
+  /**
+   * Get the minimum and maximum values of the current parameter vector.
+   * \param[out] min Minimum values of the parameters vector
+   * \param[out] max Maximum values of the parameters vector
+   */
+  void getParameterVectorAllMinMax(Eigen::VectorXd& min, Eigen::VectorXd& max) const;
+  
+  /**
+   * Get the ranges of the selected parameters, i.e. max-min, in one vector.
+   * \param[out] ranges The ranges of the selected parameters concatenated in one vector
+   */
+   inline void getParameterVectorSelectedRanges(Eigen::VectorXd& ranges) const {
+     Eigen::VectorXd min, max;
+     getParameterVectorSelectedMinMax(min, max);
+     ranges = (max.array()-min.array());
+   }
+  
+  /**
+   * Set all the values of the selected parameters with one vector.
+   * \param[in] values The new values of the selected parameters in one vector
+   * \param[in] normalized Whether the data is normalized or not
+   */
+  virtual void setParameterVectorSelected(const Eigen::VectorXd& values, bool normalized=false);
+  
+  /**
+   * Set all the values of the selected parameters with one vector of normalized values.
+   * \param[in] values The new values of the selected parameters in one vector of normalized values.
+   */
+  virtual void setParameterVectorSelectedNormalized(const Eigen::VectorXd& values) {
+    setParameterVectorSelected(values, true);
+  }
+
+  /**
+   * Determine which subset of parameters is represented in the vector returned by Parameterizable::getParameterVectorSelected
+   * 
+   * Different function approximators have different types of model parameters. For instance, LWR
+   * has the centers and widths of basis functions, along with the slopes of each line segment.
+   * Parameterizable::setSelectedParameters provides a means to determine which parameters 
+   * should be returned by Parameterizable::getParameterVectorSelected, i.e. by calling:
+   *   std::set<std::string> selected;
+   *   selected.insert("slopes");
+   *   model_parameters.setSelectedParameters(selected)
+   * \param[in] selected_values_labels The names of the parameters that are selected
+   */
+  virtual void setSelectedParameters(const std::set<std::string>& selected_values_labels);
+
+  /** Set the parameters that are currently selected. 
+   * Convenience function that allow only a string to be passed, rather than a set of strings.
+   * \param[in] selected The name of the parameters that are selected
+   */
+  void setSelectedParametersOne(std::string selected)
+  {
+    std::set<std::string> selected_set;
+    selected_set.insert(selected);
+    setSelectedParameters(selected_set);    
+  }
+  
+  /** Return all the names of the parameter types that can be selected.
+   * \param[out] selected_values_labels Names of the parameter types that can be selected
+   */
+  virtual void getSelectableParameters(std::set<std::string>& selected_values_labels) const = 0;
+
+  /**
+   * Get a mask for selecting parameters.
+   * 
+   * \param[in] selected_values_labels Labels of the selected parameter values
+   * \param[out] selected_mask A mask indicating indices of selected parameters. 0 indicates not selected, >0 indicates selected.
+   *
+   * For instance, if the parameters consists of centers, widths and slopes the 
+   * parameter values vector will be something like
+\verbatim
+    centers     widths    slopes
+[ 100 110 120 10 10 10 0.4 0.7 0.4 ]
+\endverbatim
+   * In this case, if selected_values_labels contains "centers" and "slopes", the mask will be:
+\verbatim
+    centers     widths    slopes
+[   1   1   1  0  0  0   3   3   3 ]
+\endverbatim
+   * The '0' indicates that these parameters are not selected.
+   * The other ones have different numbers so that they may be discerned from one another (as
+   * required in Parameterizable::getParameterVectorSelectedMinMax for instance.
+   */
+  virtual void getParameterVectorMask(const std::set<std::string> selected_values_labels, Eigen::VectorXi& selected_mask) const = 0;
+  
+  /** Get the size of the parameter values vector when it contains all available
+   * parameter values.
+   * \return The size of the parameter vector
+   *
+   * For instance, if the parameters consists of centers, widths and slopes the 
+   * parameter values vector will be something like
+\verbatim
+    centers     widths    slopes
+[ 100 110 120 10 10 10 0.4 0.7 0.4 ]
+\endverbatim
+   * then getParameterVectorAllSize() will return 9 
+   */
+  virtual int getParameterVectorAllSize(void) const = 0;
+  
+  /** Return a vector that returns all available parameter values.
+   * \param[out] values All available parameter values in one vector.
+   * \remarks Contrast this with Parameterizable::getParameterVectorSelected, which return only
+   * the SELECTED parameter values. Selecting parameters is done with
+   * Parameterizable::setSelectedParameters
+   */
+  virtual void getParameterVectorAll(Eigen::VectorXd& values) const = 0;
+  
+  //void getParameterVectorAllNormalized(Eigen::VectorXd& values_normalized) const;
+
+  /** Set all available parameter values with one vector.
+   * \param[in] values All available parameter values in one vector.
+   * \remarks Contrast this with Parameterizable::setParameterVectorSelected, which sets only
+   * the SELECTED parameter values. Selecting parameters is done with
+   * Parameterizable::setSelectedParameters
+   */
+  virtual void setParameterVectorAll(const Eigen::VectorXd& values) = 0;
+    
+  /** Turn certain modifiers on or off.
+   *
+   * This can be used to modify exactly what is returned by Parameterizable::getParameterVectorAll(). 
+   * For an example, see ModelParametersLWR::setParameterVectorModifierPrivate()
+   *
+   * This function calls the virtual private function Parameterizable::setParameterVectorModifierPrivate(), which may (but must not be) overridden by subclasses of Parameterizable.
+   *
+   * \param[in] modifier The name of the modifier
+   * \param[in] new_value Whether to turn the modifier on (true) or off (false)
+   */
+  void setParameterVectorModifier(std::string modifier, bool new_value);
+  
+  
+  /**
+   * \todo Document this
+   */
+  void setVectorLengthsPerDimension(Eigen::VectorXi lengths_per_dimension)
+  {
+    assert(lengths_per_dimension.sum()==getParameterVectorSelectedSize());
+    lengths_per_dimension_ = lengths_per_dimension;
+  }
+  
+  /**
+   * Get the values of the selected parameters in one vector.
+   * \param[out] values The selected parameters concatenated in one vector
+   * \param[in] normalized Whether to normalize the data or not
+   * \remarks The lenghts of each Eigen::VectorXd in the std::vector is set with Parameterizable::setVectorLengthsPerDimension()
+   */
+  void getParameterVectorSelected(std::vector<Eigen::VectorXd>& values, bool normalized=false) const;
+  
+  /**
+   * Set all the values of the selected parameters with a vector of vectors.
+   * \param[in] values The new values of the selected parameters in one vector
+   * \param[in] normalized Whether the data is normalized or not
+   * \remarks The lenghts of each Eigen::VectorXd in the std::vector is set with Parameterizable::setVectorLengthsPerDimension()
+   */
+  void setParameterVectorSelected(const std::vector<Eigen::VectorXd>& values, bool normalized=false);
+
+  
+private:
+  /** Turn certain modifiers on or off, see Parameterizable::setParameterVectorModifier().
+   *
+   * Parameterizable::setParameterVectorModifierPrivate(), This function may (but must not be) overridden by subclasses of Parameterizable, depending on whether the subclass has modifiers (or not)
+   *
+   * \param[in] modifier The name of the modifier
+   * \param[in] new_value Whether to turn the modifier on (true) or off (false)
+   */
+  virtual void setParameterVectorModifierPrivate(std::string modifier, bool new_value)
+  {
+    // Can be overridden by subclasses
+  }
+  
+  Eigen::VectorXi selected_mask_;
+
+  /** 
+   * \see Parameterizable::setVectorLengthsPerDimension()
+   */
+  Eigen::VectorXi lengths_per_dimension_;
+  
+  // Since this is a cached variable, it needs to be mutable so that const functions may change it.
+  mutable Eigen::VectorXd parameter_vector_all_initial_;
+  /** Give boost serialization access to private members. */  
+  friend class boost::serialization::access;
+  
+  /** Serialize class data members to boost archive. 
+   * \param[in] ar Boost archive
+   * \param[in] version Version of the class
+   * See http://www.boost.org/doc/libs/1_55_0/libs/serialization/doc/tutorial.html#simplecase
+   */
+  template<class Archive>
+  void serialize(Archive & ar, const unsigned int version)
+  {
+    ar & BOOST_SERIALIZATION_NVP(selected_mask_);
+    ar & BOOST_SERIALIZATION_NVP(parameter_vector_all_initial_);
+  }
+
+};
+
+}
+
+
+#include <boost/serialization/assume_abstract.hpp>
+/** Tell boost serialization that this class has pure virtual functions. */
+BOOST_SERIALIZATION_ASSUME_ABSTRACT(DmpBbo::Parameterizable);
+ 
+#include <boost/serialization/export.hpp>
+/** Don't add version information to archives. */
+BOOST_CLASS_IMPLEMENTATION(DmpBbo::Parameterizable,boost::serialization::object_serializable);
+
+#endif


### PR DESCRIPTION
May 2, 2014: 
Added commit with sigmoid system changes. See commit e2b91b0 for comments.

----------------------------------------

saveToDirectory(vector<UpdateSummary> upsumvec ...) has been modified to accept a new boolean argument -> bool stack_updates which allows the user to add to the same master CMA updates directory if multiple optimizations are run for the same dmp. The argument is defaulted to FALSE in UpdateSummariesParallel.hpp. This seemed cleaner than adding a new function, but could pose an issue if the user wanted to overwrite a particular set of optimization runs but use this same continued numbering format. This sort of problem is probably best left to the user because of the particularity of this implementation. Compiles and runs fine.

P.S. I do not know why the .cpp and .hpp files show so many changes but the only changes are lines 96-116 and 157.