### PR TITLE
Changed doxygen error to warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ option(BUILD_DOCUMENTATION "Use Doxygen to create the HTML based API documentati
 if(BUILD_DOCUMENTATION)
   FIND_PACKAGE(Doxygen)
   if (NOT DOXYGEN_FOUND)
-    message(FATAL_ERROR 
+    message(WARNING 
       "Doxygen is needed to build the documentation. Please install it correctly")
   endif()
   #-- Configure the Template Doxyfile for our specific project


### PR DESCRIPTION
The documentation should be mandatory.
If doxygen is not installed on the system, we get a FATAL_ERROR message, which stops the build.
Giving a warning message allows to build without the docs.
