### PR TITLE
real time eigen allocation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ project(OO_DMP_BBO)
 
 # Some settings related to building/installing libraries and header files
 # Set this to STATIC if you want to build static libraries instead.
-option(BUILD_SHARED_LIBS "Enable this option to build shared libraries" OFF)
+option(BUILD_SHARED_LIBS "Enable this option to build shared libraries" ON)
 
 if(BUILD_SHARED_LIBS)
 set(SHARED_OR_STATIC "SHARED")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ project(OO_DMP_BBO)
 
 # Some settings related to building/installing libraries and header files
 # Set this to STATIC if you want to build static libraries instead.
-option(BUILD_SHARED_LIBS "Enable this option to build shared libraries" ON)
+option(BUILD_SHARED_LIBS "Enable this option to build shared libraries" OFF)
 
 if(BUILD_SHARED_LIBS)
 set(SHARED_OR_STATIC "SHARED")
@@ -16,20 +16,18 @@ set(SHARED_OR_STATIC "STATIC")
 endif()
 
 
-set(LIB_INSTALL_DIR /usr/local/lib)
-set(INCLUDE_INSTALL_DIR /usr/local/include)
+set(LIB_INSTALL_DIR ${CMAKE_INSTALL_PREFIX}/lib)
+set(INCLUDE_INSTALL_DIR ${CMAKE_INSTALL_PREFIX}/include)
 
 
 # Never build inside the source tree
 set(CMAKE_DISABLE_SOURCE_CHANGES ON)
 set(CMAKE_DISABLE_IN_SOURCE_BUILD ON)
 
-
-
 # Some flags for CXX
-set(CMAKE_CXX_FLAGS "-Wall -std=c++0x -fPIC")
-set(CMAKE_CXX_FLAGS_DEBUG "-O0 -ggdb")
-set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG")
+set(CMAKE_CXX_FLAGS "-Wall -std=c++0x -fPIC ${CMAKE_CXX_FLAGS}")
+set(CMAKE_CXX_FLAGS_DEBUG "-O0 -ggdb ${CMAKE_CXX_FLAGS_DEBUG}")
+set(CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG ${CMAKE_CXX_FLAGS_RELEASE}")
 
 # Define macros to check for real time requirements
 # To activate the EIGEN_MALLOC asserts use: cmake .. -DREALTIME_CHECKS=1 -DCMAKE_BUILD_TYPE=Debug
@@ -45,9 +43,9 @@ set(CMAKE_MODULE_PATH ${oo_dmp_bbo_SOURCE_DIR}/cmake/modules "${CMAKE_SOURCE_DIR
 include_directories(${CMAKE_SOURCE_DIR}/src)
 link_directories(${CMAKE_SOURCE_DIR}/lib)
 
-IF(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-  SET(CMAKE_INSTALL_PREFIX ${CMAKE_SOURCE_DIR} CACHE PATH "Comment" FORCE)
-ENDIF(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+#IF(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+#  SET(CMAKE_INSTALL_PREFIX ${CMAKE_SOURCE_DIR} CACHE PATH "Comment" FORCE)
+#ENDIF(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
 
 ###############################################################################
 # See if LWPR is installed. 
@@ -58,7 +56,7 @@ endif()
 
 ###############################################################################
 # Find boost packages
-find_package( Boost 1.34 COMPONENTS filesystem system serialization REQUIRED)
+find_package( Boost COMPONENTS filesystem system serialization REQUIRED)
 link_directories ( ${Boost_LIBRARY_DIRS} )
 include_directories ( ${Boost_INCLUDE_DIRS} )
 

--- a/src/dmp/Dmp.cpp
+++ b/src/dmp/Dmp.cpp
@@ -794,7 +794,7 @@ string Dmp::toString(void) const
   RETURN_STRING_FROM_BOOST_SERIALIZATION_XML("Dmp");
 }
 
-
+/*
 template<class Archive>
 void Dmp::serialize(Archive & ar, const unsigned int version)
 {
@@ -807,6 +807,6 @@ void Dmp::serialize(Archive & ar, const unsigned int version)
   ar & BOOST_SERIALIZATION_NVP(phase_system_);
   ar & BOOST_SERIALIZATION_NVP(gating_system_);
   ar & BOOST_SERIALIZATION_NVP(function_approximators_);
-}
+}*/
 
 }

--- a/src/dmp/Dmp.hpp
+++ b/src/dmp/Dmp.hpp
@@ -387,7 +387,7 @@ private:
    * See http://www.boost.org/doc/libs/1_55_0/libs/serialization/doc/tutorial.html#simplecase
    */
   template<class Archive>
-  void serialize(Archive & ar, const unsigned int version);
+  void serialize(Archive & ar, const unsigned int version){}
 
 };
 

--- a/src/functionapproximators/FunctionApproximator.cpp
+++ b/src/functionapproximators/FunctionApproximator.cpp
@@ -229,7 +229,7 @@ void FunctionApproximator::setParameterVectorAll(const Eigen::VectorXd& values) 
     model_parameters_->setParameterVectorAll(values);
 };
 
-string FunctionApproximator::toString(void) const
+string FunctionApproximator::toStr(void) const
 {
   string name = "FunctionApproximator"+getName();
   RETURN_STRING_FROM_BOOST_SERIALIZATION_XML(name.c_str());

--- a/src/functionapproximators/FunctionApproximator.hpp
+++ b/src/functionapproximators/FunctionApproximator.hpp
@@ -219,14 +219,14 @@ public:
    * subclasses: http://stackoverflow.com/questions/4571611/virtual-operator
    */ 
   friend std::ostream& operator<<(std::ostream& output, const FunctionApproximator& function_approximator) {
-    output << function_approximator.toString();
+    output << function_approximator.toStr();
     return output;
   }
   
   /** Returns a string representation of the object.
    * \return A string representation of the object.
    */
-  std::string toString(void) const;
+  std::string toStr(void) const;
   
   
   /** Accessor for FunctionApproximator::meta_parameters_

--- a/src/functionapproximators/FunctionApproximatorGMR.cpp
+++ b/src/functionapproximators/FunctionApproximatorGMR.cpp
@@ -339,7 +339,10 @@ void FunctionApproximatorGMR::predict(const Eigen::MatrixXd& inputs, Eigen::Matr
         // inv(C_x) * C_y_x^T
         covar_input_times_output_.noalias() = gmm->covars_x_inv_[i_gau]*gmm->covars_y_x_[i_gau].transpose();
         // - C_y_x * inv(C_x) * C_y_x^T
-        covar_output_prealloc_.noalias() = - gmm->covars_y_x_[i_gau] * covar_input_times_output_;
+        covar_output_prealloc_.noalias() = gmm->covars_y_x_[i_gau] * covar_input_times_output_;
+        // NOTE: covar_output_prealloc_.noalias() = - gmm->covars_y_x_[i_gau] * covar_input_times_output_; causes memory allocation
+        // so we split it in two operations
+        covar_output_prealloc_.noalias() = - covar_output_prealloc_;
         // (C_y - C_y_x * inv(C_x) * C_y_x^T) 
         covar_output_prealloc_ += gmm->covars_y_[i_gau];
         // h^2 * (C_y - C_y_x * inv(C_x) * C_y_x^T) 
@@ -504,7 +507,10 @@ void FunctionApproximatorGMR::predictDot(const MatrixXd& inputs, MatrixXd& outpu
         // inv(C_x) * C_y_x^T
         covar_input_times_output_.noalias() = gmm->covars_x_inv_[i_gau]*gmm->covars_y_x_[i_gau].transpose();
         // - C_y_x * inv(C_x) * C_y_x^T
-        covar_output_prealloc_.noalias() = - gmm->covars_y_x_[i_gau] * covar_input_times_output_;
+        covar_output_prealloc_.noalias() = gmm->covars_y_x_[i_gau] * covar_input_times_output_;
+        // NOTE: covar_output_prealloc_.noalias() = - gmm->covars_y_x_[i_gau] * covar_input_times_output_; causes memory allocation
+        // so we split it in two operations
+        covar_output_prealloc_.noalias() = - covar_output_prealloc_;
         // (C_y - C_y_x * inv(C_x) * C_y_x^T) 
         covar_output_prealloc_ += gmm->covars_y_[i_gau];
         // h^2 * (C_y - C_y_x * inv(C_x) * C_y_x^T) 

--- a/src/functionapproximators/MetaParameters.cpp
+++ b/src/functionapproximators/MetaParameters.cpp
@@ -49,7 +49,7 @@ MetaParameters::~MetaParameters(void)
 }
 
 ostream& operator<<(std::ostream& output, const MetaParameters& meta_parameters) {
-  output << meta_parameters.toString();
+  output << meta_parameters.toStr();
   return output;
 }
 

--- a/src/functionapproximators/MetaParameters.hpp
+++ b/src/functionapproximators/MetaParameters.hpp
@@ -71,7 +71,7 @@ public:
   /** Returns a string representation of the object.
    * \return A string representation of the object.
    */
-  virtual std::string toString(void) const = 0;
+  virtual std::string toStr(void) const = 0;
 
   /** Print to output stream. 
    *

--- a/src/functionapproximators/MetaParametersGMR.cpp
+++ b/src/functionapproximators/MetaParametersGMR.cpp
@@ -61,7 +61,7 @@ void MetaParametersGMR::serialize(Archive & ar, const unsigned int version)
   ar & BOOST_SERIALIZATION_NVP(number_of_gaussians_);
 }
 
-string MetaParametersGMR::toString(void) const 
+string MetaParametersGMR::toStr(void) const
 {
   RETURN_STRING_FROM_BOOST_SERIALIZATION_XML("MetaParametersGMR");
 }

--- a/src/functionapproximators/MetaParametersGMR.hpp
+++ b/src/functionapproximators/MetaParametersGMR.hpp
@@ -46,7 +46,7 @@ public:
 	
 	MetaParametersGMR* clone(void) const;
 
-	std::string toString(void) const;
+    std::string toStr(void) const;
   
 private:
   /** Number of gaussians */

--- a/src/functionapproximators/MetaParametersGPR.cpp
+++ b/src/functionapproximators/MetaParametersGPR.cpp
@@ -84,7 +84,7 @@ void MetaParametersGPR::serialize(Archive & ar, const unsigned int version)
   ar & BOOST_SERIALIZATION_NVP(sigmas_);
 }
 
-string MetaParametersGPR::toString(void) const
+string MetaParametersGPR::toStr(void) const
 {
   RETURN_STRING_FROM_BOOST_SERIALIZATION_XML("MetaParametersGPR");
 }

--- a/src/functionapproximators/MetaParametersGPR.hpp
+++ b/src/functionapproximators/MetaParametersGPR.hpp
@@ -57,7 +57,7 @@ public:
 		 
 	MetaParametersGPR* clone(void) const;
 
-	std::string toString(void) const;
+    std::string toStr(void) const;
 	
 	/** Return the maximum covariance of the covariance function. 
 	 * \return Maximum covariance

--- a/src/functionapproximators/MetaParametersIRFRLS.cpp
+++ b/src/functionapproximators/MetaParametersIRFRLS.cpp
@@ -66,7 +66,7 @@ void MetaParametersIRFRLS::serialize(Archive & ar, const unsigned int version)
   ar & BOOST_SERIALIZATION_NVP(gamma_);
 }
 
-string MetaParametersIRFRLS::toString(void) const 
+string MetaParametersIRFRLS::toStr(void) const
 {
   RETURN_STRING_FROM_BOOST_SERIALIZATION_XML("MetaParametersIRFRLS");
 }

--- a/src/functionapproximators/MetaParametersIRFRLS.hpp
+++ b/src/functionapproximators/MetaParametersIRFRLS.hpp
@@ -50,7 +50,7 @@ public:
 	
 	MetaParametersIRFRLS* clone(void) const;
 	
-  std::string toString(void) const;
+  std::string toStr(void) const;
 
 private:
 

--- a/src/functionapproximators/MetaParametersLWR.cpp
+++ b/src/functionapproximators/MetaParametersLWR.cpp
@@ -203,7 +203,7 @@ void MetaParametersLWR::serialize(Archive & ar, const unsigned int version)
   ar & BOOST_SERIALIZATION_NVP(asymmetric_kernels_);
 }
 
-string MetaParametersLWR::toString(void) const
+string MetaParametersLWR::toStr(void) const
 {
   RETURN_STRING_FROM_BOOST_SERIALIZATION_XML("MetaParametersLWR");
 }

--- a/src/functionapproximators/MetaParametersLWR.hpp
+++ b/src/functionapproximators/MetaParametersLWR.hpp
@@ -95,7 +95,7 @@ public:
 
 	MetaParametersLWR* clone(void) const;
 
-	std::string toString(void) const;
+    std::string toStr(void) const;
 
 private:
   Eigen::VectorXi n_bfs_per_dim_; // should be const

--- a/src/functionapproximators/MetaParametersRBFN.cpp
+++ b/src/functionapproximators/MetaParametersRBFN.cpp
@@ -199,7 +199,7 @@ void MetaParametersRBFN::serialize(Archive & ar, const unsigned int version)
   ar & BOOST_SERIALIZATION_NVP(intersection_height_);
 }
 
-string MetaParametersRBFN::toString(void) const
+string MetaParametersRBFN::toStr(void) const
 {
   RETURN_STRING_FROM_BOOST_SERIALIZATION_XML("MetaParametersRBFN");
 }

--- a/src/functionapproximators/MetaParametersRBFN.hpp
+++ b/src/functionapproximators/MetaParametersRBFN.hpp
@@ -83,7 +83,7 @@ public:
 	
 	MetaParametersRBFN* clone(void) const;
 
-	std::string toString(void) const;
+    std::string toStr(void) const;
 
 private:
   Eigen::VectorXi n_bfs_per_dim_; // should be const

--- a/src/functionapproximators/ModelParameters.hpp
+++ b/src/functionapproximators/ModelParameters.hpp
@@ -48,7 +48,7 @@ public:
    */
   virtual ModelParameters* clone(void) const = 0;
   
-  virtual ~ModelParameters(void) {};
+  virtual ~ModelParameters(void) {}
 
   /** Print to output stream. 
    *
@@ -60,14 +60,14 @@ public:
    * subclasses: http://stackoverflow.com/questions/4571611/virtual-operator
    */ 
    friend std::ostream& operator<<(std::ostream& output, const ModelParameters& model_parameters) {
-    output << model_parameters.toString();
+    output << model_parameters.toStr();
     return output;
   }
   
   /** Returns a string representation of the object.
    * \return A string representation of the object.
    */
-  virtual std::string toString(void) const = 0;
+  virtual std::string toStr(void) const = 0;
   
   /** The expected dimensionality of the input data.
    * \return Expected dimensionality of the input data
@@ -113,11 +113,11 @@ public:
 
 /** Tell boost serialization that this class has pure virtual functions. */
 #include <boost/serialization/assume_abstract.hpp>
-BOOST_SERIALIZATION_ASSUME_ABSTRACT(DmpBbo::ModelParameters);
+BOOST_SERIALIZATION_ASSUME_ABSTRACT(DmpBbo::ModelParameters)
  
 /** Don't add version information to archives. */
 #include <boost/serialization/export.hpp>
-BOOST_CLASS_IMPLEMENTATION(DmpBbo::ModelParameters,boost::serialization::object_serializable);
+BOOST_CLASS_IMPLEMENTATION(DmpBbo::ModelParameters,boost::serialization::object_serializable)
 
 #endif //  #ifndef MODELPARAMETERS_H
 

--- a/src/functionapproximators/ModelParametersGMR.cpp
+++ b/src/functionapproximators/ModelParametersGMR.cpp
@@ -205,7 +205,7 @@ void ModelParametersGMR::serialize(Archive & ar, const unsigned int version)
 }
 
 
-string ModelParametersGMR::toString(void) const 
+string ModelParametersGMR::toStr(void) const
 {
   RETURN_STRING_FROM_BOOST_SERIALIZATION_XML("ModelParametersGMR");
 };

--- a/src/functionapproximators/ModelParametersGMR.hpp
+++ b/src/functionapproximators/ModelParametersGMR.hpp
@@ -69,7 +69,7 @@ public:
 	};
 
 	
-	std::string toString(void) const;
+    std::string toStr(void) const;
 
   ModelParameters* clone(void) const;
 

--- a/src/functionapproximators/ModelParametersGPR.cpp
+++ b/src/functionapproximators/ModelParametersGPR.cpp
@@ -122,7 +122,7 @@ void ModelParametersGPR::serialize(Archive & ar, const unsigned int version)
                                     
 }
 
-string ModelParametersGPR::toString(void) const
+string ModelParametersGPR::toStr(void) const
 {
   RETURN_STRING_FROM_BOOST_SERIALIZATION_XML("ModelParametersGPR");
 }

--- a/src/functionapproximators/ModelParametersGPR.hpp
+++ b/src/functionapproximators/ModelParametersGPR.hpp
@@ -60,7 +60,7 @@ public:
    */
    ModelParametersGPR(const Eigen::MatrixXd& train_inputs, const Eigen::VectorXd& train_targets, const Eigen::MatrixXd& gram, double maximum_covariance, const Eigen::VectorXd& sigmas);
    
-  std::string toString(void) const;
+  std::string toStr(void) const;
   
 	ModelParameters* clone(void) const;
 	

--- a/src/functionapproximators/ModelParametersIRFRLS.cpp
+++ b/src/functionapproximators/ModelParametersIRFRLS.cpp
@@ -116,7 +116,7 @@ void ModelParametersIRFRLS::serialize(Archive & ar, const unsigned int version)
   ar & BOOST_SERIALIZATION_NVP(all_values_vector_size_);
 }
 
-string ModelParametersIRFRLS::toString(void) const 
+string ModelParametersIRFRLS::toStr(void) const
 {
   RETURN_STRING_FROM_BOOST_SERIALIZATION_XML("ModelParametersIRFRLS");
 };

--- a/src/functionapproximators/ModelParametersIRFRLS.hpp
+++ b/src/functionapproximators/ModelParametersIRFRLS.hpp
@@ -48,7 +48,7 @@ public:
 	
 	int getExpectedInputDim(void) const;
 	
-	std::string toString(void) const;
+    std::string toStr(void) const;
 
   ModelParameters* clone(void) const;
 

--- a/src/functionapproximators/ModelParametersLWR.cpp
+++ b/src/functionapproximators/ModelParametersLWR.cpp
@@ -259,7 +259,7 @@ void ModelParametersLWR::serialize(Archive & ar, const unsigned int version)
   ar & BOOST_SERIALIZATION_NVP(caching_);
 }
 
-string ModelParametersLWR::toString(void) const
+string ModelParametersLWR::toStr(void) const
 {
   RETURN_STRING_FROM_BOOST_SERIALIZATION_XML("ModelParametersLWR");
 }

--- a/src/functionapproximators/ModelParametersLWR.hpp
+++ b/src/functionapproximators/ModelParametersLWR.hpp
@@ -52,7 +52,7 @@ public:
    */
   ModelParametersLWR(const Eigen::MatrixXd& centers, const Eigen::MatrixXd& widths, const Eigen::MatrixXd& slopes, const Eigen::MatrixXd& offsets, bool asymmetric_kernels=false, bool lines_pivot_at_max_activation=false);
   
-  std::string toString(void) const;
+  std::string toStr(void) const;
   
 	ModelParameters* clone(void) const;
 	

--- a/src/functionapproximators/ModelParametersRBFN.cpp
+++ b/src/functionapproximators/ModelParametersRBFN.cpp
@@ -121,7 +121,7 @@ void ModelParametersRBFN::serialize(Archive & ar, const unsigned int version)
   ar & BOOST_SERIALIZATION_NVP(caching_);
 }
 
-string ModelParametersRBFN::toString(void) const
+string ModelParametersRBFN::toStr(void) const
 {
   RETURN_STRING_FROM_BOOST_SERIALIZATION_XML("ModelParametersRBFN");
 }

--- a/src/functionapproximators/ModelParametersRBFN.hpp
+++ b/src/functionapproximators/ModelParametersRBFN.hpp
@@ -53,7 +53,7 @@ public:
    */
   ModelParametersRBFN(const Eigen::MatrixXd& centers, const Eigen::MatrixXd& widths, const Eigen::MatrixXd& weights);
   
-  std::string toString(void) const;
+  std::string toStr(void) const;
   
 	ModelParameters* clone(void) const;
 	

--- a/src/functionapproximators/UnifiedModel.cpp
+++ b/src/functionapproximators/UnifiedModel.cpp
@@ -403,7 +403,7 @@ void UnifiedModel::serialize(Archive & ar, const unsigned int version)
   ar & BOOST_SERIALIZATION_NVP(caching_);
 }
 
-string UnifiedModel::toString(void) const
+string UnifiedModel::toStr(void) const
 {
   RETURN_STRING_FROM_BOOST_SERIALIZATION_XML("UnifiedModel");
 }

--- a/src/functionapproximators/UnifiedModel.hpp
+++ b/src/functionapproximators/UnifiedModel.hpp
@@ -97,7 +97,7 @@ public:
   /** Returns a string representation of the object.
    * \return A string representation of the object.
    */
-  std::string toString(void) const;
+  std::string toStr(void) const;
   
   /** Return a pointer to a deep copy of the object.
    *  \return Pointer to a deep copy


### PR DESCRIPTION
Commit: 5205d40cefd8572df20aa30cf682a942e7268f98
Eigen allocates memory when you have this kind of operation:

MatrixXd m1(3,1);
MatrixXd m2(1,3);
MatrixXd m3(3,3);

START_REALTIME_CODE
m3.noalias() = - m1 * m2;
END_REALTIME_CODE

The allocation is related to the scalar multiplication. By splitting in two lines the expression the allocation disappears:

START_REALTIME_CODE
m3.noalias() = m1 * m2;
m3.noalias() = - m3;
END_REALTIME_CODE

