### PR TITLE
Bug fixes to apply for the DmpWithGainSchdules

### DIFF
--- a/demo_robot/robotPerformRollout.cpp
+++ b/demo_robot/robotPerformRollout.cpp
@@ -113,7 +113,7 @@ int main(int n_args, char** args)
     else
     {
       // Set DMP parameters to sample
-      dmp->setParameterVectorSelected(sample);
+      dmp->setParameterVector(sample);
       // Save dmp whose parameters have been perturbed, if necessary
       if (!dmp_output_filename.empty())
       {

--- a/demo_robot/step1A_trainDmpFromTrajectoryFile.cpp
+++ b/demo_robot/step1A_trainDmpFromTrajectoryFile.cpp
@@ -132,7 +132,6 @@ int main(int n_args, char** args)
   
   // Initialize the DMP
   Dmp* dmp = new Dmp(n_dims, function_approximators, Dmp::KULVICIUS_2012_JOINING);
-  dmp->set_name("trained");
 
   cout << "C++    |     Training Dmp... (n_basis_functions=" << n_basis_functions << ")" << endl;
   bool overwrite = true;

--- a/demo_robot/step1A_trainDmpFromTrajectoryFile.cpp
+++ b/demo_robot/step1A_trainDmpFromTrajectoryFile.cpp
@@ -149,7 +149,7 @@ int main(int n_args, char** args)
   
   // Save the initial parameter vector to file
   Eigen::VectorXd parameter_vector;
-  dmp->getParameterVectorSelected(parameter_vector);
+  dmp_gains->getParameterVector(parameter_vector);
   overwrite = true;
   cout << "C++    |     Writing initial parameter vector to file : " << output_parameters_file << endl;
   saveMatrix(output_parameters_file,parameter_vector,overwrite);

--- a/demos_cpp/dmp_bbo/demoImitationAndOptimization.cpp
+++ b/demos_cpp/dmp_bbo/demoImitationAndOptimization.cpp
@@ -74,7 +74,7 @@ void runImitationAndOptimization(vector<FunctionApproximator*> function_approxim
 
   // Make the initial distribution
   vector<VectorXd> mean_init_vec;
-  dmp->getParameterVectorSelected(mean_init_vec);
+  dmp->getParameterVector(mean_init_vec);
   
   int n_dims = dmp->dim_orig();
   vector<DistributionGaussian*> distributions(n_dims);

--- a/demos_cpp/dmp_bbo/demoImitationAndOptimization.cpp
+++ b/demos_cpp/dmp_bbo/demoImitationAndOptimization.cpp
@@ -73,15 +73,15 @@ void runImitationAndOptimization(vector<FunctionApproximator*> function_approxim
   TaskSolverDmp* task_solver = new TaskSolverDmp(dmp,parameters_to_optimize);
 
   // Make the initial distribution
-  VectorXd mean_init_vec;
+  vector<VectorXd> mean_init_vec;
   dmp->getParameterVector(mean_init_vec);
   
   int n_dims = dmp->dim_orig();
   vector<DistributionGaussian*> distributions(n_dims);
   for (int i_dim=0; i_dim<n_dims; i_dim++)
   {
-    cout << mean_init_vec.transpose() << endl;
-    VectorXd mean_init = mean_init_vec;
+    cout << mean_init_vec[i_dim].transpose() << endl;
+    VectorXd mean_init = mean_init_vec[i_dim];
   
     MatrixXd covar_init = 1000.0*MatrixXd::Identity(mean_init.size(),mean_init.size());
     

--- a/demos_cpp/dmp_bbo/demoImitationAndOptimization.cpp
+++ b/demos_cpp/dmp_bbo/demoImitationAndOptimization.cpp
@@ -73,15 +73,15 @@ void runImitationAndOptimization(vector<FunctionApproximator*> function_approxim
   TaskSolverDmp* task_solver = new TaskSolverDmp(dmp,parameters_to_optimize);
 
   // Make the initial distribution
-  vector<VectorXd> mean_init_vec;
+  VectorXd mean_init_vec;
   dmp->getParameterVector(mean_init_vec);
   
   int n_dims = dmp->dim_orig();
   vector<DistributionGaussian*> distributions(n_dims);
   for (int i_dim=0; i_dim<n_dims; i_dim++)
   {
-    cout << mean_init_vec[i_dim].transpose() << endl;
-    VectorXd mean_init = mean_init_vec[i_dim];
+    cout << mean_init_vec.transpose() << endl;
+    VectorXd mean_init = mean_init_vec;
   
     MatrixXd covar_init = 1000.0*MatrixXd::Identity(mean_init.size(),mean_init.size());
     

--- a/demos_cpp/dmp_bbo/demoOptimizationDmp.cpp
+++ b/demos_cpp/dmp_bbo/demoOptimizationDmp.cpp
@@ -116,7 +116,7 @@ int main(int n_args, char* args[])
   
   // Make the initial distribution
   VectorXd mean_init;
-  dmp->getParameterVectorSelected(mean_init);
+  dmp->getParameterVector(mean_init);
   
   MatrixXd covar_init = 1000.0*MatrixXd::Identity(mean_init.size(),mean_init.size());
 

--- a/demos_cpp/dmp_bbo/demoOptimizationDmpArm2D.cpp
+++ b/demos_cpp/dmp_bbo/demoOptimizationDmpArm2D.cpp
@@ -118,7 +118,7 @@ int main(int n_args, char* args[])
   
   // Make the initial distribution
   VectorXd mean_init;
-  dmp->getParameterVectorSelected(mean_init);
+  dmp->getParameterVector(mean_init);
   
   MatrixXd covar_init = 1000.0*MatrixXd::Identity(mean_init.size(),mean_init.size());
 

--- a/demos_cpp/dmp_bbo/demoOptimizationDmpParallel.cpp
+++ b/demos_cpp/dmp_bbo/demoOptimizationDmpParallel.cpp
@@ -113,14 +113,14 @@ int main(int n_args, char* args[])
   
 
   // Make the initial distribution
-  vector<VectorXd> mean_init_vec;
+  VectorXd mean_init_vec;
   dmp->getParameterVector(mean_init_vec);
   
   vector<DistributionGaussian*> distributions(n_dim);
   for (int i_dim=0; i_dim<n_dim; i_dim++)
   {
     //cout << mean_init_vec[i_dim].transpose() << endl;
-    VectorXd mean_init = mean_init_vec[i_dim];
+    VectorXd mean_init = mean_init_vec;
   
     MatrixXd covar_init = 1000.0*MatrixXd::Identity(mean_init.size(),mean_init.size());
     

--- a/demos_cpp/dmp_bbo/demoOptimizationDmpParallel.cpp
+++ b/demos_cpp/dmp_bbo/demoOptimizationDmpParallel.cpp
@@ -114,7 +114,7 @@ int main(int n_args, char* args[])
 
   // Make the initial distribution
   vector<VectorXd> mean_init_vec;
-  dmp->getParameterVectorSelected(mean_init_vec);
+  dmp->getParameterVector(mean_init_vec);
   
   vector<DistributionGaussian*> distributions(n_dim);
   for (int i_dim=0; i_dim<n_dim; i_dim++)

--- a/demos_cpp/dmp_bbo/demoOptimizationDmpParallel.cpp
+++ b/demos_cpp/dmp_bbo/demoOptimizationDmpParallel.cpp
@@ -113,14 +113,14 @@ int main(int n_args, char* args[])
   
 
   // Make the initial distribution
-  VectorXd mean_init_vec;
+  vector<VectorXd> mean_init_vec;
   dmp->getParameterVector(mean_init_vec);
   
   vector<DistributionGaussian*> distributions(n_dim);
   for (int i_dim=0; i_dim<n_dim; i_dim++)
   {
     //cout << mean_init_vec[i_dim].transpose() << endl;
-    VectorXd mean_init = mean_init_vec;
+    VectorXd mean_init = mean_init_vec[i_dim];
   
     MatrixXd covar_init = 1000.0*MatrixXd::Identity(mean_init.size(),mean_init.size());
     

--- a/src/dmp/Dmp.cpp
+++ b/src/dmp/Dmp.cpp
@@ -756,7 +756,10 @@ bool Dmp::isParameterSelected(std::string label) const {
 
 void Dmp::getParameterVector(VectorXd& values, bool normalized) const
 {
-  values.resize(getParameterVectorSize());
+  // Here a programming decision has to be made: Without Dmp:: the getParameterVectorSize is taken from DmpWithGainSchedules
+  // One possibilty is to change all the necessary functions or to adapt the code to be compatible with DmpWithGainSchedules
+  // Before the getParameterVectorSize got the size of the DMP + the gains
+  values.resize(Dmp::getParameterVectorSize());
   int offset = 0;
   VectorXd cur_values;
   VectorXd attractor = attractor_state();

--- a/src/dmp/Dmp.cpp
+++ b/src/dmp/Dmp.cpp
@@ -777,6 +777,23 @@ void Dmp::getParameterVector(VectorXd& values, bool normalized) const
   }
 }
 
+void Dmp::getParameterVector(std::vector<Eigen::VectorXd>& vector_values, bool normalized) const
+{
+  // Not tested yet
+  VectorXd cur_values;
+  VectorXd attractor = attractor_state();
+  for (int dd=0; dd<dim_orig(); dd++)
+  {
+    function_approximators_[dd]->getParameterVector(cur_values, normalized);
+
+    if (isParameterSelected("goal")) {
+      // ggg Goal is not normalized
+      cur_values(cur_values.size()-2) = attractor(dd);
+    }
+    vector_values.push_back(cur_values);
+  }
+}
+
 void Dmp::setParameterVector(const VectorXd& values, bool normalized)
 {
   assert(values.size()==getParameterVectorSize());

--- a/src/dmp/Dmp.hpp
+++ b/src/dmp/Dmp.hpp
@@ -304,6 +304,7 @@ public:
 
   virtual int getParameterVectorSize(void) const;
   virtual void getParameterVector(Eigen::VectorXd& values, bool normalized=false) const;
+  virtual void getParameterVector(std::vector<Eigen::VectorXd>& vector_values, bool normalized=false) const;
   virtual void setParameterVector(const Eigen::VectorXd& values, bool normalized=false);
   virtual void setParameterVector(const std::vector<Eigen::VectorXd>& vector_values, bool normalized=false);
   bool isParameterSelected(std::string label) const;

--- a/src/dmp/DmpWithGainSchedules.cpp
+++ b/src/dmp/DmpWithGainSchedules.cpp
@@ -325,7 +325,6 @@ void DmpWithGainSchedules::setSelectedParameters(const set<string>& selected_val
   set<string> labels_gains;
   for (string label : selected_values_labels) {
       if (label.find("_gains") != string::npos) {
-        // Before the labels were not updated
         label = label.substr(0,label.length()-6); // Remove '_gains' 
         labels_gains.insert(label);
       }
@@ -372,7 +371,7 @@ void DmpWithGainSchedules::setParameterVector(const VectorXd& values, bool norma
   int n_params_for_dmp = Dmp::getParameterVectorSize();
 
   VectorXd values_for_dmp = values.segment(0,n_params_for_dmp);
-  Dmp::setParameterVector(values_for_dmp);
+  Dmp::setParameterVector(values_for_dmp, normalized);
 
   int offset = n_params_for_dmp;
   VectorXd cur_values;
@@ -397,7 +396,7 @@ void DmpWithGainSchedules::setParameterVector(const std::vector<Eigen::VectorXd>
   set<string> labels_gains;
   for (string label : selected_param_labels_) {
       if (label.find("_gains") != string::npos) {
-        label.substr(0,label.length()-6); // Remove '_gains' 
+        label = label.substr(0,label.length()-6); // Remove '_gains' 
         labels_gains.insert(label);
       }
   }

--- a/src/dmp/DmpWithGainSchedules.cpp
+++ b/src/dmp/DmpWithGainSchedules.cpp
@@ -325,7 +325,8 @@ void DmpWithGainSchedules::setSelectedParameters(const set<string>& selected_val
   set<string> labels_gains;
   for (string label : selected_values_labels) {
       if (label.find("_gains") != string::npos) {
-        label.substr(0,label.length()-6); // Remove '_gains' 
+        // Before the labels were not updated
+        label = label.substr(0,label.length()-6); // Remove '_gains' 
         labels_gains.insert(label);
       }
   }
@@ -375,7 +376,8 @@ void DmpWithGainSchedules::setParameterVector(const VectorXd& values, bool norma
 
   int offset = n_params_for_dmp;
   VectorXd cur_values;
-  for (int dd=dim_gains()-1; dd>=0; dd--)
+  // Before the gains were in the wrong order.
+  for (int dd=0; dd<dim_gains(); dd++)
   {
     int n_parameters_required = function_approximators_gains_[dd]->getParameterVectorSize();
     cur_values = values.segment(offset,n_parameters_required);

--- a/src/functionapproximators/FunctionApproximator.hpp
+++ b/src/functionapproximators/FunctionApproximator.hpp
@@ -376,23 +376,23 @@ The life-cycle of a function approximator is as follows:
 
 \subsection sec_fa_changing_modelparameters Changing the ModelParameters of a FunctionApproximator
 
-The user should not be allowed to set the ModelParameters of a trained function approximator directly. Hence, FunctionApproximator::setModelParameters is protected. However, in order to change the values inside the model parameters (for instance when optimizing them), the user may call ModelParameters::getParameterVectorSelected and ModelParameters::setParameterVectorSelected it inherits these functions from Parameterizable). These take a vector of doubles, check if the vector has the right size, and get/set the ModelParameters accordingly.
+The user should not be allowed to set the ModelParameters of a trained function approximator directly. Hence, FunctionApproximator::setModelParameters is protected. However, in order to change the values inside the model parameters (for instance when optimizing them), the user may call ModelParameters::getParameterVector and ModelParameters::setParameterVector it inherits these functions from Parameterizable). These take a vector of doubles, check if the vector has the right size, and get/set the ModelParameters accordingly.
 
-Function approximators often have different types of model parameters. For instance, the model parameters of Locally Weighted Regression (FunctionApproximatorLWR) represent the centers and widths of the basis functions, as well as the slopes of the line segments. If you only want to get/set the slopes when calling ModelParameters::getParameterVectorSelected and ModelParameters::setParameterVectorSelected, you must use ModelParameters::setSelectedParameters(const std::set<std::string>& selected_values_labels), for instance as follows:
+Function approximators often have different types of model parameters. For instance, the model parameters of Locally Weighted Regression (FunctionApproximatorLWR) represent the centers and widths of the basis functions, as well as the slopes of the line segments. If you only want to get/set the slopes when calling ModelParameters::getParameterVector and ModelParameters::setParameterVector, you must use ModelParameters::setSelectedParameters(const std::set<std::string>& selected_values_labels), for instance as follows:
 
 \code
 std::set<std::string> selected;
 selected.insert("slopes");
 model_parameters.setSelectedParameters(selected);
 Eigen::VectorXd values;
-model_parameters.getParameterVectorSelected(values);
+model_parameters.getParameterVector(values);
 // "values" now only contains the slopes of the line segments
 
 selected.clear();
 selected.insert("centers");
 selected.insert("slopes");
 model_parameters.setSelectedParameters(selected);
-model_parameters.getParameterVectorSelected(values);
+model_parameters.getParameterVector(values);
 // "values" now contains the centers of the basis functions AND slopes of the line segments
 
 \endcode


### PR DESCRIPTION
In this pull request, some bug fixes were fixed and two functionality issues were discovered. Functionality in the demo_robot works but a couple of decisions should be made before merging. It is commented on the files but here I explain with a bit more detail.
In [demoImitationAndOptimization.cpp](https://github.com/stulp/dmpbbo/compare/cpp_parameterizable...ignacio-pm:parametizable_fix?expand=1#diff-6f720489f3271c0ea515e6d4d68759453a40d76bd4058e7b48783a99e6ff8fc0) and [demos_cpp/dmp_bbo/demoOptimizationDmp.cpp](https://github.com/stulp/dmpbbo/compare/cpp_parameterizable...ignacio-pm:parametizable_fix?expand=1#diff-ed746c031fa8feee1c8930ef629f6dd369e13764747640dcee8192d4e76f28de) I got a compiling error because of introducing a vector of VectorXd in the getParameterVector function. I am not sure of the reason because the only thing that changed was the name of the function. Since I did not need these demos for my experiment, I deleted the vector functionality as a quick fix.

In line 762 of [src/dmp/Dmp.cpp](https://github.com/stulp/dmpbbo/compare/cpp_parameterizable...ignacio-pm:parametizable_fix?expand=1#diff-688d5308a665be1166cb3c7e4809c09edc1fe764c190e3575c98c0cfc24cccb2) I noticed that when calling getParameterVectorSize in Dmp::getParameterVector from DmpWithGainSchedules, it used DmpWithGainSchedules::getParameterVectorSize and not Dmp::getParameterVectorSize. This caused an error in the size of the vector. It should be decided if it is desired to call Dmp::getParameterVectorSize by specifying the prefix Dmp:: or to change the functionality of the whole class. There might be more functions that would be affected too.

Check if the change of the loop of line 378 of [src/dmp/DmpWithGainSchedules.cpp](https://github.com/stulp/dmpbbo/compare/cpp_parameterizable...ignacio-pm:parametizable_fix?expand=1#diff-0c3d99380fa19621a7d619bc2785b7fcd957bbfca9844b88b211c31837abafca) affects the functionality (I do not think so).