### PR TITLE
Minor link fixes in markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ The core functionality is in the Python package <a href="dmpbbo/">dmpbbo/</a>. I
   systems, as well as several specific implementations (exponential system, sigmoid system, 
   spring-damper system, etc.)
 
-+ <a href="dmpbbo/dmp">dmpbbo/dmp</a> : implementation of dynamical movement primitives, building on the functionapproximator and dynamicalsystems packages.
++ <a href="dmpbbo/dmps">dmpbbo/dmp</a> : implementation of dynamical movement primitives, building on the functionapproximator and dynamicalsystems packages.
 
 + <a href="dmpbbo/bbo">dmpbbo/bbo</a> : implementation of several evolutionary algorithms for the stochastic optimization of black-box cost functions
 

--- a/tutorial/README.md
+++ b/tutorial/README.md
@@ -8,7 +8,7 @@ To understand DMPs:
 
 1. <a href="functionapproximators.md">Function Approximators</a>
 2. <a href="dynamicalsystems.md">Dynamical Systems</a>
-3. <a href="dmps.md">Dynamical Movement Primitives</a>
+3. <a href="dmp.md">Dynamical Movement Primitives</a>
 
 To understand the optimization of DMPs:
 


### PR DESCRIPTION
Some links in markdown files were broken. This CL fixes it.